### PR TITLE
JiTA 3.0: ISD credits tracker + shared worker for model, ranking & credits

### DIFF
--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -7752,13 +7752,15 @@ JiTA.credits = {
     running: false,
     _quiet: false,        // background (scheduled) runs set this true so the floating pill stays hidden (the badge is the visible artifact)
     _cssInjected: false,
+    _flashTimer: null,
 
-    // ---- progress (page-independent floating pill + console; shows with or without the Similar Defects panel) --
-    // A multi-minute crawl needs live feedback. _pill updates a fixed-position status pill (and the panel line
-    // when it exists); _log additionally breadcrumbs to the console. Use _pill for every-item ticks (smooth,
-    // no console spam) and _log for phase changes / interval milestones.
+    // ---- progress (bottom-right pill + console ONLY; never the Triage Assistant panel line) ----------------
+    // A multi-minute crawl needs live feedback, shown solely in the fixed bottom-right pill. _pill updates the
+    // pill; _log also breadcrumbs to the console; _flash shows a brief pill message even during a quiet
+    // background run. Use _pill for every-item ticks (smooth), _log for phase milestones.
     _pill: function (msg) {
         if (JiTA.credits._quiet) { return; }   // scheduled background runs stay silent
+        if (JiTA.credits._flashTimer) { clearTimeout(JiTA.credits._flashTimer); JiTA.credits._flashTimer = null; }   // cancel a pending flash auto-clear
         try {
             var el = document.getElementById('jita-credits-progress');
             if (!el) {
@@ -7772,11 +7774,19 @@ JiTA.credits = {
             }
             el.textContent = '📊 ISD credits\n' + msg;
         } catch (e) { /* ignore */ }
-        try { JiTA.ui.setStatus('Credits: ' + msg); } catch (e2) { /* ignore */ }   // also feed the panel line when present
     },
     _log: function (msg) { JiTA.credits._pill(msg); if (window.console) { console.log('[JiTA] credits: ' + msg); } },
     _clearProgress: function () {
         try { var el = document.getElementById('jita-credits-progress'); if (el && el.parentNode) { el.parentNode.removeChild(el); } } catch (e) { /* ignore */ }
+    },
+    // Briefly show the bottom-right pill (even during a quiet background run), then auto-clear. Keeps run
+    // completion / error status in the pill and off the Triage Assistant panel line.
+    _flash: function (msg, ms) {
+        var wasQuiet = JiTA.credits._quiet;
+        JiTA.credits._quiet = false;
+        JiTA.credits._pill(msg);
+        JiTA.credits._quiet = wasQuiet;
+        JiTA.credits._flashTimer = setTimeout(function () { JiTA.credits._clearProgress(); }, ms || 4000);
     },
 
     // ---- REST (session-authenticated, read-only) --------------------------------------------------------
@@ -8220,14 +8230,12 @@ JiTA.credits = {
         return JiTA.credits.computeMonth(y, m, mentor).then(function (res) {
             return JiTA.credits.putCached(res).then(function () {
                 JiTA.credits.running = false;
-                JiTA.credits._clearProgress();
-                JiTA.ui.setStatus('Credits ' + res.ym + ' ready (' + Math.round((Date.now() - t0) / 1000) + 's)');
+                JiTA.credits._flash('Credits ' + res.ym + ' ready (' + Math.round((Date.now() - t0) / 1000) + 's)');
                 return res;
             });
         }).catch(function (e) {
             JiTA.credits.running = false;
-            JiTA.credits._clearProgress();
-            JiTA.ui.setStatus('Credits error: ' + (e && e.message || e));
+            JiTA.credits._flash('Credits error: ' + (e && e.message || e), 8000);
             throw e;
         });
     },

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Jira Triage Assistant
-// @version     2.39.0
+// @version     3.0.0
 // @author      ISD BH Schogol, ISD Tulwar
 // @description Adds a Translate, Assign to GM, Convert to Defect and Close button to Jira, parses Log Files submitted from the EVE client, suggests similar existing defects on bug reports, and (on a defect) lists the open bug reports that best match it
 // @updateURL   https://github.com/Schogol/Jira-Triage-Assistant/raw/main/JiTA.user.js
@@ -2761,6 +2761,10 @@ JiTA.logsig = {
     // Every OTHER defect that shares a signature with `key` (deduped across all of the key's signatures),
     // each with its status/resolution. Drives the inline "Same exception" section on a defect. [] when none.
     siblingsForKey: function (key) {
+        if (JiTA.worker && JiTA.worker._started) { return JiTA.worker.call('logsig', { op: 'siblings', key: key }).catch(function () { return JiTA.logsig._siblingsLocal(key); }); }
+        return JiTA.logsig._siblingsLocal(key);
+    },
+    _siblingsLocal: function (key) {
         return JiTA.logsig.ensure().then(function (idx) {
             var out = [], seen = {};
             seen[key] = true;
@@ -2783,6 +2787,10 @@ JiTA.logsig = {
     // sibling - i.e. the SAME bug reached via a DIFFERENT call path. Looser than siblingsForKey; drives the
     // "Possibly related" hint. [] when none.
     relatedForKey: function (key) {
+        if (JiTA.worker && JiTA.worker._started) { return JiTA.worker.call('logsig', { op: 'related', key: key }).catch(function () { return JiTA.logsig._relatedLocal(key); }); }
+        return JiTA.logsig._relatedLocal(key);
+    },
+    _relatedLocal: function (key) {
         return JiTA.logsig.ensure().then(function (idx) {
             if (!idx) { return []; }
             var exclude = {};
@@ -2812,6 +2820,10 @@ JiTA.logsig = {
     // first (the freshly-recurring exceptions a triager most wants to see), with cluster size as the
     // tiebreaker. Drives the "Exception clusters" overview.
     clusters: function () {
+        if (JiTA.worker && JiTA.worker._started) { return JiTA.worker.call('logsig', { op: 'clusters' }).catch(function () { return JiTA.logsig._clustersLocal(); }); }
+        return JiTA.logsig._clustersLocal();
+    },
+    _clustersLocal: function () {
         function newest(members) {
             var n = '';
             for (var i = 0; i < members.length; i++) {
@@ -3025,6 +3037,10 @@ JiTA.logsig = {
     // swallow the whole rest of the log (hundreds of unrelated `file.py(NN) func` lines) and the stack
     // signature would never match the clean one in the index. Resolves to { defect -> { defect, count, msg } }.
     matchText: function (text) {
+        if (JiTA.worker && JiTA.worker._started) { return JiTA.worker.call('logsig', { op: 'match', text: text }).catch(function () { return JiTA.logsig._matchTextLocal(text); }); }
+        return JiTA.logsig._matchTextLocal(text);
+    },
+    _matchTextLocal: function (text) {
         return JiTA.logsig.ensure().then(function (idx) {
             var found = {};
             if (!idx || !text) { return found; }
@@ -4546,7 +4562,7 @@ JiTA.sync = {
         });
     },
 
-    // Wipe the local DB and rebuild from scratch (also used after a model-version change in Phase 2).
+    // Wipe the local DB and rebuild from scratch (also used after an embedding model-version change).
     rebuild: function () {
         if (JiTA.sync.running) { JiTA.ui.toast('A sync is already running…'); return Promise.resolve(); }
         if (!confirm('Rebuild the local defect database from scratch? This re-fetches every EDR/EO/PLAT issue.')) { return Promise.resolve(); }
@@ -4809,8 +4825,24 @@ JiTA.rank = {
         });
     },
 
-    // Rank stored defects against the query text. Returns up to `limit` (default TOP_N) scored results.
+    // Keyword (BM25) defect candidates. Routes to the shared worker's index (so tabs don't build one), gating
+    // tab-side; on worker failure, falls back to a locally-built BM25 index (the ONLY time _index is built here).
     suggest: function (text, excludeKey, limit, filterTerms) {
+        if (JiTA.worker && JiTA.worker._started) {
+            return JiTA.rank._workerKeyword(text, 'defects', excludeKey, filterTerms, limit)
+                .then(function (cands) { return JiTA.rank._gateScored(cands, 'defects').slice(0, limit || JiTA.TOP_N); })
+                .catch(function () { return JiTA.rank._suggestLocal(text, excludeKey, limit, filterTerms); });
+        }
+        return JiTA.rank._suggestLocal(text, excludeKey, limit, filterTerms);
+    },
+    _workerKeyword: function (text, scope, excludeKey, filterTerms, limit) {
+        return JiTA.worker.call('rankKeyword', {
+            text: text, scope: scope, excludeKey: excludeKey,
+            filterTerms: (filterTerms && filterTerms.length ? filterTerms : null),
+            topN: Math.max((limit || JiTA.TOP_N) * 4, 100)
+        }).then(function (r) { return (r && r.results) || []; });
+    },
+    _suggestLocal: function (text, excludeKey, limit, filterTerms) {
         return JiTA.rank._ensureIndex().then(function (idx) {
             return JiTA.rank._bm25Score(idx, text, excludeKey, limit, filterTerms);
         });
@@ -4825,9 +4857,22 @@ JiTA.rank = {
         });
     },
 
-    // Rank OPEN bug reports against the query text (a defect's text). Returns up to `limit` scored results,
-    // each with a display `pct` relative to the top score. Mirrors `suggest` but over the EBR index.
+    // Rank OPEN bug reports against the query text (a defect's text), each with a display `pct` relative to the
+    // top score. Worker-backed (with local fallback), mirroring suggest.
     suggestEbr: function (text, excludeKey, limit, filterTerms) {
+        function withPct(scored) {
+            var top = (scored[0] && scored[0].score) || 0;
+            for (var p = 0; p < scored.length; p++) { scored[p].pct = top > 0 ? Math.round(scored[p].score / top * 100) : 0; }
+            return scored;
+        }
+        if (JiTA.worker && JiTA.worker._started) {
+            return JiTA.rank._workerKeyword(text, 'ebr', excludeKey, filterTerms, limit)
+                .then(function (cands) { return withPct(JiTA.rank._gateScored(cands, 'ebr').slice(0, limit || JiTA.TOP_N)); })
+                .catch(function () { return JiTA.rank._suggestEbrLocal(text, excludeKey, limit, filterTerms); });
+        }
+        return JiTA.rank._suggestEbrLocal(text, excludeKey, limit, filterTerms);
+    },
+    _suggestEbrLocal: function (text, excludeKey, limit, filterTerms) {
         return JiTA.rank._ensureEbrIndex().then(function (idx) {
             var scored = JiTA.rank._bm25Score(idx, text, excludeKey, limit, filterTerms);
             var top = (scored[0] && scored[0].score) || 0;
@@ -4897,8 +4942,10 @@ JiTA.rank._bm25Score = function (idx, text, excludeKey, limit, filterTerms) {
 };
 
 
-/* ---- embedding engine: local transformers.js (Phase 2) ----
- * Lazily loads a small sentence-embedding model in the browser (no server, no API key) and embeds
+/* ---- embedding engine: local transformers.js (main-thread fallback) ----
+ * The shared worker hosts the primary embedding engine now (one model for all tabs). This local copy is
+ * the fallback path for when the worker never comes up (no Web Locks / BroadcastChannel / module workers):
+ * it lazily loads the same small sentence-embedding model in THIS tab (no server, no API key) and embeds
  * defect text into 384-dim normalized vectors. CSP on this instance is permissive (only frame-ancestors,
  * WASM OK), so we load the library with a plain dynamic import() of a pinned CDN ESM build and let it
  * fetch model weights directly. Any failure flips `unavailable` and the ranking layer falls back to BM25.
@@ -5121,6 +5168,20 @@ JiTA.embed = {
     // Background entry point: load the model and embed anything outstanding, then refresh the panel.
     // Idempotent per session unless `force` is passed (used right after a sync brings in new/changed text).
     prepare: function (force) {
+        // With the shared worker, embedding runs THERE (one model for all tabs) - no main-thread model load.
+        // Any tab can trigger it; the request routes to the single leader worker, which is single-flight.
+        if (JiTA.worker && JiTA.worker._started) {
+            if (JiTA.embed._preparing) { return JiTA.embed._preparing; }
+            JiTA.embed._preparing = JiTA.worker.call('embedPass').then(function (r) {
+                JiTA.embed._preparing = null;
+                if (r && r.embedded > 0) { try { JiTA.ui.scheduleRender(); } catch (e) { /* ignore */ } }   // new vectors -> re-rank the open view
+            }, function (e) {
+                JiTA.embed._preparing = null;
+                console.log('[JiTA] worker embed pass skipped:', (e && e.message) || e);
+            });
+            return JiTA.embed._preparing;
+        }
+        // Fallback (no worker at all): the original main-thread embed pass.
         if (JiTA.embed.unavailable) { return Promise.resolve(); }
         if (JiTA.embed._preparing) { return JiTA.embed._preparing; }
         if (JiTA.embed._prepared && !force) { return Promise.resolve(); }
@@ -5130,8 +5191,6 @@ JiTA.embed = {
                 JiTA.embed._prepared = true;
                 JiTA.rank._dirtyVec = true;
                 JiTA.rank._dirtyEbrVec = true;
-                // Refresh whichever view is open (coalesced, so a sync + this embed-pass completion collapse
-                // into a single list rebuild instead of thrashing): EBR -> similar defects, EDR -> reports.
                 JiTA.ui.scheduleRender();
             });
         }).then(function () {
@@ -5145,40 +5204,7 @@ JiTA.embed = {
 };
 
 
-/* ---- semantic ranking (Phase 2): cosine over stored embeddings, with BM25 fallback ---- */
-JiTA.rank._vecIndex = null;     // cached array of { key, project, summary, status, resolution, vec }
-JiTA.rank._dirtyVec = true;     // rebuild the in-memory vector cache on next semantic query
-JiTA.rank._buildingVec = null;
-
-// Shared body of the two vector indexes (_ensureVecIndex / _ensureEbrVecIndex): the current-model embedded
-// docs, filtered by `keep` (defects = non-EBR; open reports = EBR & not closed). resolutiondate is carried
-// uniformly (unused on the EBR side, harmless).
-JiTA.rank._buildVecIndex = function (records, keep) {
-    var docs = [];
-    for (var i = 0; i < records.length; i++) {
-        var r = records[i];
-        if (!keep(r)) { continue; }
-        if (r.embedding && r.embeddingModelVersion === JiTA.MODEL_VERSION) {
-            docs.push({ key: r.key, project: r.project, summary: r.summary, status: r.status, resolution: r.resolution, resolutiondate: r.resolutiondate, created: r.created, vec: r.embedding, hay: ((r.key || '') + ' ' + (r.summary || '') + ' ' + (r.description || '')).toLowerCase() });
-        }
-    }
-    return docs;
-};
-
-// Build (and cache) the in-memory list of DEFECT vectors for the current model version.
-JiTA.rank._ensureVecIndex = function () {
-    return JiTA.rank._ensureCached('_vecIndex', '_dirtyVec', '_buildingVec', function (recs) {
-        return JiTA.rank._buildVecIndex(recs, function (r) { return r.project !== 'EBR'; });
-    });
-};
-
-// Cosine similarity of two normalized vectors == dot product.
-JiTA.rank._dot = function (a, b) {
-    var s = 0, n = Math.min(a.length, b.length);
-    for (var i = 0; i < n; i++) { s += a[i] * b[i]; }
-    return s;
-};
-
+/* ---- ranking fusion: semantic + BM25 candidates come from the shared worker; RRF-fused here ---- */
 JiTA.rank.CAND = 50;     // candidates pulled from each retriever before fusion
 JiTA.rank.RRF_K = 60;    // Reciprocal-Rank-Fusion constant (standard default)
 
@@ -5210,79 +5236,44 @@ JiTA.rank._fuse = function (sem, bm, demote) {
     return topN;
 };
 
-// Embed the query text, caching the most recent (text -> vector) so filter-box keystrokes (which re-rank the
-// SAME issue text against a changing filter) don't re-run the transformer every time - only the filter +
-// scoring re-run, not the expensive inference.
-JiTA.rank._qvText = null;
-JiTA.rank._qvVec = null;
-JiTA.rank._embedQuery = function (text) {
-    if (JiTA.rank._qvText === text && JiTA.rank._qvVec) { return Promise.resolve(JiTA.rank._qvVec); }
-    return JiTA.embed.embedOne(text).then(function (qv) {
-        JiTA.rank._qvText = text; JiTA.rank._qvVec = qv; return qv;
-    });
+// Semantic candidates from the SHARED worker (embed + cosine live in the worker's one model+index, not per tab).
+// Returns the worker's top-K score-sorted candidate list, or rejects if the worker is unavailable (caller then
+// keyword-falls-back). filterTerms is applied in the worker; the remaining session/UI gates run tab-side below.
+JiTA.rank._workerSemantic = function (text, scope, excludeKey, filterTerms) {
+    if (!JiTA.worker || !JiTA.worker._started) { return Promise.reject(new Error('worker off')); }
+    return JiTA.worker.call('rankSemantic', {
+        text: text, scope: scope, excludeKey: excludeKey,
+        filterTerms: (filterTerms && filterTerms.length ? filterTerms : null),
+        topN: JiTA.rank.CAND * 4
+    }).then(function (r) { return (r && r.results) || []; });
 };
 
-// Cosine-score every doc from `indexGetter()` (a Promise of a vec index) against the query vector, applying
-// the exclude / hidden / filter-box / session-filter gates, sorted best-first. [] if none embedded. Shared by
-// the defect and open-EBR semantic scorers (identical loop; resolutiondate is carried uniformly - unused on
-// the EBR side, harmless). `filterTerms` restricts to docs whose key+title+description contains them all.
-JiTA.rank._cosineScored = function (indexGetter, qv, excludeKey, filterTerms) {
-    return indexGetter().then(function (docs) {
-        var scored = [];
-        for (var d = 0; d < docs.length; d++) {
-            if (excludeKey && docs[d].key === excludeKey) { continue; }
-            if (JiTA.hidden.isHidden(docs[d].key)) { continue; }   // user-hidden suggestion (temporary, persisted across updates)
-            if (filterTerms && filterTerms.length && !JiTA.rank._matchTerms(docs[d].hay, filterTerms)) { continue; }
-            if (!JiTA.ui.passesFilter(docs[d])) { continue; }   // session filters (status / recency)
-            var sc = JiTA.rank._dot(qv, docs[d].vec);
-            if (!isFinite(sc)) { continue; }   // defensively drop any corrupt (NaN/Inf) vector
-            scored.push({ key: docs[d].key, project: docs[d].project, summary: docs[d].summary, status: docs[d].status, resolution: docs[d].resolution, resolutiondate: docs[d].resolutiondate, score: sc });
-        }
-        scored.sort(function (a, c) { return c.score - a.score; });
-        return scored;
-    });
+// Apply the tab-side gates the worker doesn't know about to the worker's pre-scored candidates: user-hidden
+// suggestions, the structural open+non-GM filter for matching-reports (ebr scope), and the session status/recency
+// filter. Candidates arrive score-sorted, so order is preserved. Returns the semantic list for fusion.
+JiTA.rank._gateScored = function (cands, scope) {
+    var out = [];
+    for (var i = 0; i < cands.length; i++) {
+        var d = cands[i];
+        if (JiTA.hidden.isHidden(d.key)) { continue; }
+        if (scope === 'ebr' && (JiTA.util.isClosedStatus(d.status) || JiTA.util.isGmTeam(d.team))) { continue; }
+        if (!JiTA.ui.passesFilter(d)) { continue; }
+        out.push({ key: d.key, project: d.project, summary: d.summary, status: d.status, resolution: d.resolution, resolutiondate: d.resolutiondate, score: d.score });
+    }
+    return out;
 };
 
-// Cosine-score the DEFECT vectors against the query. [] if none embedded.
-JiTA.rank._semanticScored = function (qv, excludeKey, filterTerms) {
-    return JiTA.rank._cosineScored(JiTA.rank._ensureVecIndex, qv, excludeKey, filterTerms);
-};
-
-/* ---- EBR semantic ranking (stage 2): cosine over OPEN bug-report embeddings ---- */
-JiTA.rank._ebrVecIndex = null;
-JiTA.rank._dirtyEbrVec = true;
-JiTA.rank._buildingEbrVec = null;
-
-// In-memory vector list over OPEN bug reports (project EBR) with a current-version embedding. Mirrors
-// _ensureVecIndex but keeps only open EBRs (closed ones aren't ranked and lose their slot).
-JiTA.rank._ensureEbrVecIndex = function () {
-    return JiTA.rank._ensureCached('_ebrVecIndex', '_dirtyEbrVec', '_buildingEbrVec', function (recs) {
-        return JiTA.rank._buildVecIndex(recs, function (r) { return r.project === 'EBR' && !JiTA.util.isClosedStatus(r.status) && !JiTA.util.isGmTeam(r.team); });
-    });
-};
-
-// Cosine-score the OPEN-EBR vectors against the query. [] if none embedded.
-JiTA.rank._semanticScoredEbr = function (qv, excludeKey, filterTerms) {
-    return JiTA.rank._cosineScored(JiTA.rank._ensureEbrVecIndex, qv, excludeKey, filterTerms);
-};
-
-// Shared HYBRID body for suggestBest / suggestEbrBest: embed the query, cosine-score via semFn, fall back to
-// keyword when nothing is embedded (or the filter excluded all), else pull the BM25 candidates via bmFn and
-// RRF-fuse (with optional `demote`, defect side only). A query-time embed failure (e.g. a WebGPU device loss)
-// drops the possibly-dead pipeline - we do NOT auto-switch backend, that's the user's menu choice - and shows
-// keyword results for now.
-JiTA.rank._hybridResults = function (text, key, filterTerms, semFn, bmFn, keywordOnly, demote) {
-    return JiTA.rank._embedQuery(text).then(function (qv) {
-        return semFn(qv, key, filterTerms).then(function (sem) {
-            if (!sem.length) { return keywordOnly(); }
-            return bmFn(text, key, JiTA.rank.CAND, filterTerms).then(function (bm) {
-                return { mode: 'Hybrid', results: JiTA.rank._fuse(sem, bm, demote) };
-            });
+// Shared HYBRID body for suggestBest / suggestEbrBest: pull semantic candidates from the shared worker, gate them
+// tab-side, then RRF-fuse with the local BM25 candidates (with optional `demote`, defect side only). If the worker
+// is unavailable / errors / yields nothing usable, fall back to keyword-only.
+JiTA.rank._hybridResults = function (text, key, filterTerms, scope, bmFn, keywordOnly, demote) {
+    return JiTA.rank._workerSemantic(text, scope, key, filterTerms).then(function (cands) {
+        var sem = JiTA.rank._gateScored(cands, scope);
+        if (!sem.length) { return keywordOnly(); }
+        return bmFn(text, key, JiTA.rank.CAND, filterTerms).then(function (bm) {
+            return { mode: 'Hybrid', results: JiTA.rank._fuse(sem, bm, demote) };
         });
-    }).catch(function () {
-        JiTA.embed._resetPipe();
-        return keywordOnly();
-    });
+    }).catch(function () { return keywordOnly(); });
 };
 
 // Shared mode-selection tail: honor a forced Keyword override, go straight to hybrid() when the model is ready,
@@ -5291,20 +5282,18 @@ JiTA.rank._hybridResults = function (text, key, filterTerms, semFn, bmFn, keywor
 // keyword() now (prepare()'s later re-render upgrades it once the model is ready).
 JiTA.rank._pickMode = function (forceMode, keywordOnly, hybrid) {
     if (forceMode === 'Keyword') { return keywordOnly(); }
-    if (JiTA.embed.ready) { return hybrid(); }
-    if (JiTA.embed.unavailable) { return keywordOnly(); }
-    JiTA.embed.prepare();
+    if (!JiTA.worker || !JiTA.worker._started) { return keywordOnly(); }   // no shared worker -> keyword only
+    // Keyword-first: race the worker-backed hybrid against a short window. If the worker answers in time we show
+    // Hybrid straight away; otherwise show Keyword now and, once the (cold-starting) worker finally responds,
+    // re-render to upgrade to Hybrid. hybrid() itself keyword-falls-back if the worker errors.
     return new Promise(function (resolve) {
         var settled = false;
         var timer = setTimeout(function () { if (settled) { return; } settled = true; resolve(keywordOnly()); }, JiTA.embed.WARM_WAIT_MS);
-        JiTA.embed.load().then(function () {
-            if (settled) { return; }
-            settled = true; clearTimeout(timer);
-            resolve(hybrid());
+        hybrid().then(function (res) {
+            if (settled) { try { JiTA.ui.scheduleRender(); } catch (e) { /* ignore */ } return; }   // late: upgrade via a re-render
+            settled = true; clearTimeout(timer); resolve(res);
         }, function () {
-            if (settled) { return; }
-            settled = true; clearTimeout(timer);
-            resolve(keywordOnly());
+            if (settled) { return; } settled = true; clearTimeout(timer); resolve(keywordOnly());
         });
     });
 };
@@ -5343,7 +5332,7 @@ JiTA.rank.suggestBest = function (text, key, brCreated, forceMode, filterTerms) 
     }
     // HYBRID (semantic + keyword, RRF-fused) over the DEFECT indexes, with stale-match demotion.
     function hybrid() {
-        return JiTA.rank._hybridResults(text, key, filterTerms, JiTA.rank._semanticScored, JiTA.rank.suggest, keywordOnly, demote);
+        return JiTA.rank._hybridResults(text, key, filterTerms, 'defects', JiTA.rank.suggest, keywordOnly, demote);
     }
     return JiTA.rank._pickMode(forceMode, keywordOnly, hybrid);
 };
@@ -5360,7 +5349,7 @@ JiTA.rank.suggestEbrBest = function (text, key, forceMode, filterTerms) {
     }
     // HYBRID over the OPEN-EBR indexes; no stale-demotion (open reports have no fix date).
     function hybrid() {
-        return JiTA.rank._hybridResults(text, key, filterTerms, JiTA.rank._semanticScoredEbr, JiTA.rank.suggestEbr, keywordOnly);
+        return JiTA.rank._hybridResults(text, key, filterTerms, 'ebr', JiTA.rank.suggestEbr, keywordOnly);
     }
     return JiTA.rank._pickMode(forceMode, keywordOnly, hybrid);
 };
@@ -7753,6 +7742,9 @@ JiTA.credits = {
     _quiet: false,        // background (scheduled) runs set this true so the floating pill stays hidden (the badge is the visible artifact)
     _cssInjected: false,
     _flashTimer: null,
+    _tagSeq: 0,           // per-tab counter -> unique progress tag for a worker crawl (scopes the pill to THIS tab)
+    _workerTag: null,     // tag of the in-flight worker crawl THIS tab initiated (null when idle); gates progress events
+    WORKER_TIMEOUT_MS: 15 * 60 * 1000,   // a full month crawl runs minutes; give the worker RPC ample headroom vs the 30s default
 
     // ---- progress (bottom-right pill + console ONLY; never the Triage Assistant panel line) ----------------
     // A multi-minute crawl needs live feedback, shown solely in the fixed bottom-right pill. _pill updates the
@@ -8160,7 +8152,26 @@ JiTA.credits = {
     // ---- orchestration ----------------------------------------------------------------------------------
     // Compute the full per-member credit table for month (y, m). Resolves { ym, computedAt, header, table,
     // rows, nameToAcc }. `table` rows are arrays aligned to `header` (last row is the Total).
+    // The crawl is fetch + politeness-sleep heavy, so it runs in the shared worker where a hidden/unfocused
+    // tab's background timer throttling can't stall it. Falls back to the in-tab crawl (_computeMonthLocal)
+    // when the worker is unavailable; progress streams back as throttled 'creditsProgress' events -> the pill.
     computeMonth: function (y, m, mentor) {
+        var C = JiTA.credits;
+        if (JiTA.worker && JiTA.worker._started) {
+            var tag = (JiTA.sched.tabId) + ':' + (++C._tagSeq);
+            C._workerTag = tag;
+            return JiTA.worker.call('creditsMonth', { y: y, m: m, mentor: mentor || null, tag: tag }, { timeoutMs: C.WORKER_TIMEOUT_MS })
+                .then(function (res) { C._workerTag = null; return res; }, function (err) {
+                    C._workerTag = null;
+                    if (window.console) { console.log('[JiTA] credits: worker crawl failed, running in-tab:', (err && err.message) || err); }
+                    return C._computeMonthLocal(y, m, mentor);
+                });
+        }
+        return C._computeMonthLocal(y, m, mentor);
+    },
+
+    // In-tab crawl: the fallback path, and the reference implementation the worker copy (crComputeMonth) mirrors.
+    _computeMonthLocal: function (y, m, mentor) {
         var C = JiTA.credits, b = C._monthBounds(y, m);
         var ym = b.start.slice(0, 7);
         C._log(ym + ': resolving group members…');
@@ -8359,23 +8370,16 @@ JiTA.credits = {
         });
     },
 
-    // ---- shared: per-viewer derivation (your row / rank / lead-ness) ------------------------------------
-    // True if a member's display name carries a lead handle token (e.g. "ISD BH Solnichka" -> "solnichka").
-    _leadFromName: function (name) {
-        var toks = {};
-        (name || '').toLowerCase().replace(/-/g, ' ').split(/\s+/).forEach(function (t) { if (t) { toks[t] = true; } });
-        for (var l in JiTA.credits.LEADS) { if (JiTA.credits.LEADS.hasOwnProperty(l) && toks[l]) { return true; } }
-        return false;
-    },
+    // ---- shared: per-viewer derivation (your row / rank) -----------------------------------------------
     // From a computed/cached result + the viewer's accountId: the members sorted by credits desc, plus which
-    // row is the viewer's, their rank, and whether they're a lead (gates the full leaderboard).
+    // row is the viewer's and their rank.
     _derive: function (res, me) {
         var real = res.table.slice(0, res.table.length - 1).slice().sort(function (a, b) { return b[8] - a[8]; });
         var myName = null;
         for (var name in res.nameToAcc) { if (res.nameToAcc.hasOwnProperty(name) && res.nameToAcc[name] === me) { myName = name; } }
         var myRow = null, myRank = null;
         for (var i = 0; i < real.length; i++) { if (real[i][0] === myName) { myRow = real[i]; myRank = i + 1; } }
-        return { real: real, myName: myName, myRow: myRow, myRank: myRank, total: real.length, isLead: JiTA.credits._leadFromName(myName) };
+        return { real: real, myName: myName, myRow: myRow, myRank: myRank, total: real.length };
     },
 
     // ---- overlay CSS (the wide, scrollable overlay chrome; base menu CSS comes from JiTA.menu._injectCss) --
@@ -8434,26 +8438,31 @@ JiTA.credits = {
         });
 
         // The viewer's line, preferring the fresher self cache (current month) over the full-leaderboard row.
+        // `computed` distinguishes "this month was computed but you're not an ECAID member" from "not computed yet".
         function cardInfo(fullRes, selfRes, me) {
+            var computed = !!(fullRes || selfRes);
             if (selfRes && selfRes.me === me && selfRes.credits != null) {
-                return { myName: selfRes.myName, created: selfRes.created, resolved: selfRes.resolved, attached: selfRes.attached,
+                return { computed: computed, myName: selfRes.myName, created: selfRes.created, resolved: selfRes.resolved, attached: selfRes.attached,
                     trashed: selfRes.trashed, reassigned: selfRes.reassigned, actioned: selfRes.actioned, extra: selfRes.extra,
                     credits: selfRes.credits, rank: selfRes.rank, total: selfRes.total };
             }
             if (fullRes) {
                 var d = C._derive(fullRes, me);
                 if (d.myRow) {
-                    return { myName: d.myName, created: d.myRow[1], resolved: d.myRow[2], attached: d.myRow[3], trashed: d.myRow[4],
+                    return { computed: computed, myName: d.myName, created: d.myRow[1], resolved: d.myRow[2], attached: d.myRow[3], trashed: d.myRow[4],
                         reassigned: d.myRow[5], actioned: d.myRow[6], extra: d.myRow[7], credits: d.myRow[8], rank: d.myRank, total: d.total };
                 }
             }
-            return { myName: null };
+            return { computed: computed, myName: null };
         }
 
         function card(info) {
             var $c = $('<div style="background:#22272b;border:1px solid #2c333a;border-radius:8px;padding:12px 14px;"></div>');
-            $('<div style="font-weight:700;font-size:13px;margin-bottom:8px;"></div>')
-                .text(info.myName ? ('You - ' + info.myName) : 'Your account was not matched to an ECAID member').appendTo($c);
+            // Not computed -> a neutral title (the status line below explains + offers Refresh); computed but no
+            // match -> the account genuinely isn't an ECAID member.
+            var title = info.myName ? ('You - ' + info.myName)
+                : (info.computed ? 'Your account was not matched to an ECAID member' : 'Your credits for ' + sel);
+            $('<div style="font-weight:700;font-size:13px;margin-bottom:8px;"></div>').text(title).appendTo($c);
             if (info.myName && info.credits != null) {
                 // Two labelled groups so it's clear Created/Resolved are DEFECTS and Attached/Trashed/Reassigned are BUG REPORTS.
                 function group(label, parts) {
@@ -8505,6 +8514,7 @@ JiTA.credits = {
             $tbl.append($thead.append($hr));
             var $tb = $('<tbody></tbody>');
             d.real.forEach(function (row, idx) {
+                if (!row[8]) { return; }   // hide members who earned 0 credits this month (they sort last, so ranks stay intact)
                 var mine = row[0] === d.myName;
                 var $r = $('<tr></tr>').attr('style', mine ? 'background:#20303f;' : '');
                 $('<td style="padding:4px 8px;color:#7a8694;"></td>').text(idx + 1).appendTo($r);
@@ -8541,20 +8551,23 @@ JiTA.credits = {
                 var fullRes = arr[0], selfRes = arr[1], me = arr[2];
                 $scroll.empty();
                 $scroll.append($('<div id="jita-cred-card-slot"></div>').append(card(cardInfo(fullRes, selfRes, me))));
+                // Only the current month auto-refreshes (the scheduler computes _ymNow()); past months are on-demand.
+                var isCurrentMonth = (sel === C._ymNow().ym);
+                if (!isCurrentMonth) {
+                    // Warn that older months are slower: the GM-reassignment step (crAutoReassigned) crawls every bug
+                    // report touched since the month began (updated >= start, no upper bound), so further back = slower.
+                    $scroll.append($('<div class="jita-menu-status" style="margin-top:8px;color:#e0b050;"></div>')
+                        .text('Heads up: older months compute slower - the GM-reassignment step crawls every bug report touched since ' + sel + ' began, so the further back you go, the longer it takes.'));
+                }
                 if (!fullRes) {
                     $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;"></div>')
-                        .text('Leaderboard not computed yet for ' + sel + '. It refreshes automatically, or click Refresh.'));
+                        .text('Leaderboard not computed yet for ' + sel + '.' + (isCurrentMonth ? ' It refreshes automatically, or click Refresh.' : ' Click Refresh to compute it.')));
                     return;
                 }
                 var d = C._derive(fullRes, me);
-                if (d.isLead) {
-                    $scroll.append($('<div class="jita-cred-sub">Leaderboard</div>'));
-                    $scroll.append(table(fullRes, d));
-                } else {
-                    var info = cardInfo(fullRes, selfRes, me);
-                    $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;"></div>')
-                        .text('The full leaderboard is visible to leads only.' + (info.rank != null ? (' You are ranked #' + info.rank + ' of ' + info.total + '.') : '')));
-                }
+                // Full leaderboard is visible to everyone now (no lead gate).
+                $scroll.append($('<div class="jita-cred-sub">Leaderboard</div>'));
+                $scroll.append(table(fullRes, d));
                 $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;color:#7a8694;"></div>')
                     .text('Leaderboard computed ' + String(fullRes.computedAt || '').replace('T', ' ').slice(0, 16) + ' - ' + d.total + ' members. Your own total updates every ~2 min.'));
             });
@@ -8593,7 +8606,7 @@ JiTA.credits = {
             var ym = JiTA.credits._ymNow().ym;
             JiTA.credits.getSelf(ym).then(function (self) {
                 if (self && self.credits != null) {
-                    el.textContent = '📊 ' + self.credits + ' cr' + (self.rank != null ? (' · #' + self.rank + '/' + self.total) : '');
+                    el.textContent = '📊 ' + self.credits + ' Credits' + (self.rank != null ? (' · #' + self.rank + '/' + self.total) : '');
                     return;
                 }
                 // fallback: derive from the full-leaderboard cache until the first self compute lands
@@ -8601,7 +8614,7 @@ JiTA.credits = {
                     if (!res) { el.textContent = '📊 credits: —'; return; }
                     JiTA.link.currentUser().then(function (me) {
                         var d = JiTA.credits._derive(res, me);
-                        el.textContent = d.myRow ? ('📊 ' + d.myRow[8] + ' cr · #' + d.myRank + '/' + d.total) : '📊 credits: n/a';
+                        el.textContent = d.myRow ? ('📊 ' + d.myRow[8] + ' Credits · #' + d.myRank + '/' + d.total) : '📊 credits: n/a';
                     });
                 }).catch(function () { /* ignore */ });
             }).catch(function () { /* ignore */ });
@@ -8683,6 +8696,900 @@ JiTA.credits = {
 };
 
 
+// The dedicated ranking worker's BODY, written as a real function so node --check validates it and it stays
+// readable as it grows. It is serialized via toString() and blobbed into the worker, so it must be fully
+// self-contained (NO closures over page scope) - all config arrives through `cfg`. Uses dynamic import() so it
+// runs as-is in the worker. Never called in the page (references self/indexedDB/import only when run as a worker).
+function jitaWorkerBody(cfg) {
+    var pipe = null, backend = 'none', db = null, vecCache = null, kwCache = null, logsigCache = null, BATCH = 8, embedding = false;
+    var LG_MIN = 2, LG_CRASH = 2;   // logsig: min stack frames to trust a signature; innermost frames for the crash-site sig
+    var K1 = 1.5, B = 0.75, STOP = {};
+    ('the a an and or of to in for on with is are was were be been it this that these those as at by from we you they i he she his her its their our your not no but if then than so such can will would should could may might do does did has have had into over under out up down off about your yours').split(' ').forEach(function (w) { STOP[w] = true; });
+    function tokenize(text) {
+        var raw = (text || '').toLowerCase().replace(/[^a-z0-9\s]+/g, ' ').split(/\s+/), out = [];
+        for (var i = 0; i < raw.length; i++) { var t = raw[i]; if (t.length >= 2 && !STOP[t]) { out.push(t); } }
+        return out;
+    }
+    // BM25 over a { N, avgdl, df, docs } index. Applies only the excludeKey + filter-box gates (hidden / session
+    // filters stay in the tab); a filter-box match with no query-term overlap is kept as a score-0 candidate.
+    function bm25Score(idx, text, excludeKey, limit, filterTerms) {
+        if (!idx || !idx.N) { return []; }
+        var q = tokenize(text), qSet = {}, i;
+        for (i = 0; i < q.length; i++) { qSet[q[i]] = true; }
+        var terms = Object.keys(qSet);
+        if (!terms.length) { return []; }
+        var avgdl = idx.avgdl || 1, idf = {}, hasTerms = filterTerms && filterTerms.length;
+        for (i = 0; i < terms.length; i++) { var n = idx.df[terms[i]] || 0; idf[terms[i]] = Math.log(1 + (idx.N - n + 0.5) / (n + 0.5)); }
+        var scored = [];
+        for (var d = 0; d < idx.docs.length; d++) {
+            var doc = idx.docs[d];
+            if (excludeKey && doc.key === excludeKey) { continue; }
+            if (hasTerms && !matchTerms(doc.hay, filterTerms)) { continue; }
+            var score = 0;
+            for (var t = 0; t < terms.length; t++) { var tf = doc.tf[terms[t]]; if (!tf) { continue; } var denom = tf + K1 * (1 - B + B * (doc.len / avgdl)); score += idf[terms[t]] * (tf * (K1 + 1)) / denom; }
+            if (score > 0 || hasTerms) { scored.push({ key: doc.key, project: doc.project, summary: doc.summary, status: doc.status, resolution: doc.resolution, resolutiondate: doc.resolutiondate, created: doc.created, team: doc.team, score: score }); }
+        }
+        scored.sort(function (a, b) { return b.score - a.score; });
+        return scored.slice(0, limit || 50);
+    }
+
+    // ---- logsig: exception-signature mining + queries (ported from JiTA.logsig so tabs hold no logsig index) --
+    function lgSplit(text) {
+        var blocks = [], re = /EXCEPTION #[\s\S]*?(?=EXCEPTION #|$)/gi, m;
+        while ((m = re.exec(text))) { blocks.push(m[0]); if (re.lastIndex === m.index) { re.lastIndex++; } }
+        return blocks.length ? blocks : [text || ''];
+    }
+    function lgFp(text) {
+        text = (text || '').replace(/^[ \t]*\d{1,2}:\d{2}:\d{2}\t[^\t\n]*\t[^\t\n]*\t/gm, '');
+        var msg = '', mm = /Formatted exception info\s*:?\s*([\s\S]*?)(?:\bCommon path prefix\b|\bCaught at\b|\bThrown at\b|\bReported from\b|\bThread Locals\b|\bStackhash\b|\bEXCEPTION END\b|$)/i.exec(text);
+        if (mm) { msg = (mm[1] || '').replace(/\s+/g, ' ').trim(); }
+        var frames = [], fre = /([A-Za-z0-9_.\/\\-]+\.py)\((\d+)\)\s+([A-Za-z0-9_<>]+)/g, fm;
+        while ((fm = fre.exec(text))) { frames.push(fm[1].replace(/^.*[\/\\]/, '') + ':' + fm[3]); }
+        var nmsg = msg.replace(/0x[0-9a-fA-F]+/g, '0x#').replace(/\b\d+L\b/g, '#').replace(/([(\[{,]\s*)\d+/g, '$1#').replace(/\d+(\s*[)\]},])/g, '#$1').replace(/\b\d{4,}\b/g, '#');
+        var sig = frames.length >= LG_MIN ? (nmsg + '|' + frames.join('>')).toLowerCase() : null;
+        var crashSig = frames.length >= LG_MIN ? (nmsg + '|' + frames.slice(-LG_CRASH).join('>')).toLowerCase() : null;
+        return { sig: sig, crashSig: crashSig, msg: msg };
+    }
+    function lgSiblings(key) {
+        var idx = logsigCache; if (!idx) { return []; }
+        var out = [], seen = {}; seen[key] = true;
+        var sigs = idx.keyToSigs[key] || [];
+        for (var s = 0; s < sigs.length; s++) { var c = idx.sigMap[sigs[s]]; if (!c) { continue; } for (var m = 0; m < c.members.length; m++) { var mem = c.members[m]; if (seen[mem.key]) { continue; } seen[mem.key] = true; out.push(mem); } }
+        return out;
+    }
+    function lgRelated(key) {
+        var idx = logsigCache; if (!idx) { return []; }
+        var exclude = {}; exclude[key] = true;
+        var sigs = idx.keyToSigs[key] || [];
+        for (var s = 0; s < sigs.length; s++) { var sc = idx.sigMap[sigs[s]]; if (sc) { for (var e = 0; e < sc.members.length; e++) { exclude[sc.members[e].key] = true; } } }
+        var out = [], seen = {}, csigs = idx.keyToCrash[key] || [];
+        for (var c = 0; c < csigs.length; c++) { var cc = idx.crashMap[csigs[c]]; if (!cc) { continue; } for (var m = 0; m < cc.members.length; m++) { var mem = cc.members[m]; if (exclude[mem.key] || seen[mem.key]) { continue; } seen[mem.key] = true; out.push(mem); } }
+        return out;
+    }
+    function lgClusters() {
+        var idx = logsigCache; if (!idx) { return []; }
+        function newest(members) { var n = ''; for (var i = 0; i < members.length; i++) { if (members[i].created && members[i].created > n) { n = members[i].created; } } return n; }
+        var out = [];
+        Object.keys(idx.sigMap).forEach(function (sig) { var c = idx.sigMap[sig]; if (c.members.length >= 2) { out.push({ sig: sig, label: c.label, members: c.members, newest: newest(c.members) }); } });
+        out.sort(function (a, b) { if (a.newest !== b.newest) { return a.newest < b.newest ? 1 : -1; } return b.members.length - a.members.length || (a.label < b.label ? -1 : 1); });
+        return out;
+    }
+    function lgMatch(text) {
+        var idx = logsigCache, found = {}; if (!idx || !text) { return found; }
+        var lines = text.replace(/\r/g, '').split('\n'), messages = [];
+        for (var li = 0; li < lines.length; li++) { var parts = lines[li].split('\t'); messages.push(parts.length >= 4 ? parts.slice(3).join('\t') : lines[li]); }
+        function tally(blockText) {
+            var fp = lgFp(blockText);
+            var defect = (fp.sig && idx.sigMap[fp.sig]) ? idx.sigMap[fp.sig].members[0].key : null, loose = false;
+            if (!defect && fp.crashSig && idx.crashMap[fp.crashSig]) { defect = idx.crashMap[fp.crashSig].members[0].key; loose = true; }
+            if (!defect) { return; }
+            if (!found[defect]) { found[defect] = { defect: defect, count: 0, msg: fp.msg || '', loose: loose }; }
+            found[defect].count++; if (!loose) { found[defect].loose = false; } if (!found[defect].msg && fp.msg) { found[defect].msg = fp.msg; }
+        }
+        var i = 0;
+        while (i < messages.length) {
+            if (messages[i].indexOf('EXCEPTION #') === -1) { i++; continue; }
+            var blockText = messages[i], j = i + 1;
+            for (; j < messages.length; j++) { if (messages[j].indexOf('EXCEPTION #') !== -1) { break; } blockText += '\n' + messages[j]; if (messages[j].indexOf('EXCEPTION END') !== -1) { j++; break; } }
+            tally(blockText); i = j;
+        }
+        return found;
+    }
+
+    async function loadModel() {
+        if (pipe) { return pipe; }
+        var mod = await import(cfg.LIB);
+        mod.env.allowLocalModels = false;
+        mod.env.useBrowserCache = true;                                   // cache weights in CacheStorage after first download
+        try { mod.env.backends.onnx.wasm.proxy = true; } catch (e) { /* older builds */ }
+        var attempts = cfg.tryGpu ? [{ device: 'webgpu', dtype: 'fp32' }, { device: 'wasm', dtype: 'q8' }] : [{ device: 'wasm', dtype: 'q8' }];
+        var lastErr;
+        for (var i = 0; i < attempts.length; i++) {
+            try {
+                pipe = await mod.pipeline('feature-extraction', cfg.MODEL, attempts[i]);
+                backend = attempts[i].device + '/' + attempts[i].dtype;
+                BATCH = attempts[i].device === 'webgpu' ? 8 : 1;          // fp32 GPU batches; WASM one-at-a-time (batched hangs)
+                return pipe;
+            } catch (e) { lastErr = e; }
+        }
+        throw lastErr || new Error('no backend loaded');
+    }
+    async function embed(text) {
+        var p = await loadModel();
+        var out = await p(text || '', { pooling: 'mean', normalize: true });
+        return out.data;   // normalized Float32Array(384)
+    }
+    var qText = null, qVec = null;
+    async function qEmbed(text) {   // cache the last query vector so filter-box re-queries don't re-embed the same text
+        if (qText === text && qVec) { return qVec; }
+        qVec = await embed(text); qText = text; return qVec;
+    }
+    function matchTerms(hay, terms) { for (var i = 0; i < terms.length; i++) { if (hay.indexOf(terms[i]) === -1) { return false; } } return true; }
+
+    // ---- embed pass (runs HERE now, so no tab ever loads a model) --------------------------------------
+    async function embedBatch(texts) {
+        var p = await loadModel();
+        var inputs = texts.map(function (t) { return (t || ' ').slice(0, cfg.MAX_CHARS) || ' '; });
+        if (inputs.length === 1) { var o1 = await p(inputs[0], { pooling: 'mean', normalize: true }); return [new Float32Array(o1.data)]; }
+        var out = await p(inputs, { pooling: 'mean', normalize: true });
+        var dim = out.dims[out.dims.length - 1], vecs = [];
+        for (var i = 0; i < inputs.length; i++) { vecs.push(new Float32Array(out.data.subarray(i * dim, (i + 1) * dim))); }
+        return vecs;
+    }
+    // Ported verbatim from JiTA.util so the worker prepares the same embedding text the tab used to.
+    function cleanForCompare(summary, description) {
+        var s = (summary || '').replace(/\s+/g, ' ').trim();
+        var d = ' ' + (description || '') + ' ';
+        d = d.replace(/<url=[^>]*>/gi, ' ').replace(/<\/url>/gi, ' ');
+        d = d.replace(/Session Info\s*:[\s\S]*?(?=Reproduction Steps|Computer Info|$)/i, ' ');
+        d = d.replace(/Computer Info[\s\S]*$/i, ' ');
+        d = d.replace(/\b(Reproduction Steps|Description)\b\s*:?/ig, ' ');
+        d = d.replace(/\bNone\b/g, ' ');
+        d = d.replace(/\s+/g, ' ').trim();
+        return (s ? (s + '. ' + s + '. ') : '') + d;
+    }
+    function isClosedStatus(status) { return /closed|done|resolved|rejected|cancel|attached/i.test(status || ''); }
+    function teamId(v) { if (v == null) { return ''; } if (typeof v === 'string' || typeof v === 'number') { return String(v); } if (typeof v === 'object') { return String(v.id || v.value || v.teamId || v.name || ''); } return ''; }
+    function isGmTeam(v) { var id = teamId(v); if (!id) { return false; } var short = String(cfg.GM_TEAM_ID).split('-').pop(); return id === cfg.GM_TEAM_ID || id === short || id.split('-').pop() === short; }
+    function bulkPut(records) {
+        return openDb().then(function (d) {
+            return new Promise(function (resolve, reject) {
+                var tx = d.transaction('defects', 'readwrite'), store = tx.objectStore('defects');
+                for (var i = 0; i < records.length; i++) { store.put(records[i]); }
+                tx.oncomplete = function () { resolve(records.length); };
+                tx.onerror = function () { reject(tx.error); };
+            });
+        });
+    }
+    // Embed every stored record lacking a current-version embedding (defects + open non-GM EBRs), in batches,
+    // writing as we go. Single-flight; resumable. On a bad/NaN batch, reset the model and retry a few times.
+    async function embedPass() {
+        if (embedding) { return { embedded: 0, busy: true }; }
+        embedding = true;
+        try {
+            await loadModel();
+            var recs = await allRecords();
+            var todo = [];
+            for (var i = 0; i < recs.length; i++) {
+                var r = recs[i];
+                if (r.project === 'EBR' && (isClosedStatus(r.status) || isGmTeam(r.team))) { continue; }   // not ranked -> don't embed
+                if (r.embedding && r.embeddingModelVersion === cfg.MODEL_VERSION) { continue; }
+                todo.push(r);
+            }
+            if (!todo.length) { return { embedded: 0 }; }
+            var idx = 0, retries = 0;
+            while (idx < todo.length) {
+                var slice = todo.slice(idx, idx + BATCH);
+                var texts = slice.map(function (x) { return cleanForCompare(x.summary, x.description); });
+                try {
+                    var vecs = await Promise.race([
+                        embedBatch(texts),
+                        new Promise(function (_r, rej) { setTimeout(function () { rej(new Error('embed batch timeout')); }, 45000); })   // watchdog: a hung GPU batch
+                    ]);
+                    var bad = false;
+                    for (var g = 0; g < vecs.length; g++) { if (!vecs[g] || !vecs[g].length || !isFinite(vecs[g][0])) { bad = true; break; } }
+                    if (bad) { throw new Error('NaN/empty embedding (likely GPU device loss)'); }
+                    for (var j = 0; j < slice.length; j++) { slice[j].embedding = vecs[j]; slice[j].embeddingModelVersion = cfg.MODEL_VERSION; }
+                    await bulkPut(slice);
+                    idx += slice.length; retries = 0;
+                } catch (e) {
+                    pipe = null;                                  // drop the (possibly dead) pipeline and rebuild
+                    if (++retries > 3) { throw e; }
+                    await new Promise(function (r) { setTimeout(r, 1500); });
+                }
+            }
+            vecCache = null; kwCache = null; logsigCache = null;   // new vectors/text -> rebuild all indexes on the next query
+            return { embedded: todo.length };
+        } finally { embedding = false; }
+    }
+    function openDb() {
+        if (db) { return Promise.resolve(db); }
+        return new Promise(function (resolve, reject) {
+            var req = indexedDB.open(cfg.DB_NAME, cfg.DB_VERSION);   // pristine in a worker (no consent-gate wrapper)
+            req.onsuccess = function () { db = req.result; resolve(db); };
+            req.onerror = function () { reject(req.error); };
+        });
+    }
+    function allRecords() {
+        return openDb().then(function (d) {
+            if (!d.objectStoreNames.contains('defects')) { return []; }   // tab hasn't created the store yet
+            return new Promise(function (resolve, reject) {
+                var r = d.transaction('defects', 'readonly').objectStore('defects').getAll();
+                r.onsuccess = function () { resolve(r.result || []); };
+                r.onerror = function () { reject(r.error); };
+            });
+        });
+    }
+    // Build BOTH in-worker indexes in a single DB read (held ONCE for all tabs): the vector index (records
+    // embedded at the current model version) and the BM25 keyword index, each split defects vs open non-GM EBRs.
+    async function ensureIndexes() {
+        if (vecCache && kwCache && logsigCache) { return; }
+        var recs = await allRecords();
+        var vD = [], vE = [], kD = [], kE = [], dfD = {}, dfE = {}, lenD = 0, lenE = 0;
+        var sigMap = {}, keyToSigs = {}, crashMap = {}, keyToCrash = {};   // logsig
+        for (var i = 0; i < recs.length; i++) {
+            var r = recs[i], isEbr = r.project === 'EBR';
+            if (isEbr && (isClosedStatus(r.status) || isGmTeam(r.team))) { continue; }   // not ranked in the reports view
+            var hay = ((r.key || '') + ' ' + (r.summary || '') + ' ' + (r.description || '')).toLowerCase();
+            var meta = { key: r.key, project: r.project, summary: r.summary, status: r.status, resolution: r.resolution, resolutiondate: r.resolutiondate, created: r.created, team: r.team };
+            if (r.embedding && r.embeddingModelVersion === cfg.MODEL_VERSION) {
+                var ve = { key: meta.key, project: meta.project, summary: meta.summary, status: meta.status, resolution: meta.resolution, resolutiondate: meta.resolutiondate, created: meta.created, team: meta.team, vec: r.embedding, hay: hay };
+                (isEbr ? vE : vD).push(ve);
+            }
+            var toks = tokenize(cleanForCompare(r.summary, r.description)), tf = {}, seen = {}, df = isEbr ? dfE : dfD;
+            for (var j = 0; j < toks.length; j++) { var tk = toks[j]; tf[tk] = (tf[tk] || 0) + 1; if (!seen[tk]) { df[tk] = (df[tk] || 0) + 1; seen[tk] = true; } }
+            var kd = { key: meta.key, project: meta.project, summary: meta.summary, status: meta.status, resolution: meta.resolution, resolutiondate: meta.resolutiondate, created: meta.created, team: meta.team, tf: tf, len: toks.length, hay: hay };
+            if (isEbr) { kE.push(kd); lenE += toks.length; } else { kD.push(kd); lenD += toks.length; }
+            // logsig: mine exception signatures from DEFECT descriptions only
+            if (!isEbr && r.description && r.description.indexOf('EXCEPTION #') !== -1) {
+                var lmember = { key: r.key, status: r.status || '', resolution: r.resolution || null, resolutiondate: r.resolutiondate || null, created: r.created || null };
+                var blocks = lgSplit(r.description);
+                for (var b = 0; b < blocks.length; b++) {
+                    var fp = lgFp(blocks[b]);
+                    if (!fp.sig) { continue; }
+                    var csm = sigMap[fp.sig]; if (!csm) { csm = sigMap[fp.sig] = { sig: fp.sig, label: fp.msg || '', members: [] }; }
+                    if (!csm.label && fp.msg) { csm.label = fp.msg; }
+                    if (!keyToSigs[r.key]) { keyToSigs[r.key] = []; }
+                    if (keyToSigs[r.key].indexOf(fp.sig) === -1) { keyToSigs[r.key].push(fp.sig); csm.members.push(lmember); }
+                    if (fp.crashSig) {
+                        var ccm = crashMap[fp.crashSig]; if (!ccm) { ccm = crashMap[fp.crashSig] = { crashSig: fp.crashSig, label: fp.msg || '', members: [] }; }
+                        if (!ccm.label && fp.msg) { ccm.label = fp.msg; }
+                        if (!keyToCrash[r.key]) { keyToCrash[r.key] = []; }
+                        if (keyToCrash[r.key].indexOf(fp.crashSig) === -1) { keyToCrash[r.key].push(fp.crashSig); ccm.members.push(lmember); }
+                    }
+                }
+            }
+        }
+        vecCache = { defects: vD, ebr: vE };
+        kwCache = {
+            defects: { N: kD.length, avgdl: kD.length ? lenD / kD.length : 0, df: dfD, docs: kD },
+            ebr: { N: kE.length, avgdl: kE.length ? lenE / kE.length : 0, df: dfE, docs: kE }
+        };
+        function lgSort(a, b) { var ac = a.created || '', bc = b.created || ''; if (ac !== bc) { return ac < bc ? 1 : -1; } return a.key < b.key ? -1 : 1; }
+        Object.keys(sigMap).forEach(function (s) { sigMap[s].members.sort(lgSort); });
+        Object.keys(crashMap).forEach(function (s) { crashMap[s].members.sort(lgSort); });
+        logsigCache = { sigMap: sigMap, keyToSigs: keyToSigs, crashMap: crashMap, keyToCrash: keyToCrash };
+    }
+    // Cosine == dot product (both vectors are normalized). Return the top-N by score.
+    function cosineTopN(q, entries, topN, excludeKey, filterTerms) {
+        var hasTerms = filterTerms && filterTerms.length;
+        var scored = [];
+        for (var i = 0; i < entries.length; i++) {
+            var e = entries[i];
+            if (excludeKey && e.key === excludeKey) { continue; }
+            if (hasTerms && !matchTerms(e.hay, filterTerms)) { continue; }   // filter-box narrowing (session/UI gates stay in the tab)
+            var v = e.vec, s = 0, n = q.length;
+            for (var j = 0; j < n; j++) { s += q[j] * v[j]; }
+            scored.push({ key: e.key, project: e.project, summary: e.summary, status: e.status, resolution: e.resolution, resolutiondate: e.resolutiondate, created: e.created, team: e.team, score: s });
+        }
+        scored.sort(function (a, b) { return b.score - a.score; });
+        return scored.slice(0, topN || 10);
+    }
+    async function rankSemantic(payload) {
+        payload = payload || {};
+        await ensureIndexes();
+        var entries = payload.scope === 'ebr' ? vecCache.ebr : vecCache.defects;
+        var q = await qEmbed(payload.text || '');
+        return { backend: backend, indexed: entries.length, results: cosineTopN(q, entries, payload.topN || 10, payload.excludeKey, payload.filterTerms) };
+    }
+    async function rankKeyword(payload) {
+        payload = payload || {};
+        await ensureIndexes();
+        var idx = payload.scope === 'ebr' ? kwCache.ebr : kwCache.defects;
+        return { indexed: idx.N, results: bm25Score(idx, payload.text || '', payload.excludeKey, payload.topN || 200, payload.filterTerms) };
+    }
+
+    // ---- ISD credits: the monthly leaderboard crawl runs HERE now, so its fetches + politeness sleeps live off
+    // the tab's main thread and can't be background-timer-throttled when the tab is unfocused. This mirrors
+    // JiTA.credits._computeMonthLocal (the tab keeps that copy as the fallback). Same-origin fetch carries the
+    // session cookie; progress is streamed back as throttled 'creditsProgress' events tagged to the requesting tab.
+    var crc = cfg.credits || {};
+    var crActiveTags = [], crLastTick = 0;   // progress tags of the crawl currently executing (serialized: one crawl at a time)
+    var crLast = null;                       // { key, tags, promise } : the most recent crawl (running or queued), for coalescing
+    function crProgress(msg) { if (crActiveTags.length) { try { self.postMessage({ event: 'creditsProgress', tags: crActiveTags, msg: msg }); } catch (e) { /* ignore */ } } }
+    function crTick(i, total, msg) { var now = Date.now(); if (i === 0 || i + 1 === total || now - crLastTick > 400) { crLastTick = now; crProgress(msg); } }   // throttle per-item ticks so we don't flood the channel
+    function crSleep(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
+    // Session-authenticated GET (retries mirror the tab's _get: 429 + 5xx, honoring Retry-After).
+    function crGet(path) {
+        return new Promise(function (resolve, reject) {
+            (function attempt(retries) {
+                fetch(cfg.HOST + path, { credentials: 'same-origin', headers: { 'Accept': 'application/json' } }).then(function (resp) {
+                    if ((resp.status === 429 || resp.status >= 500) && retries > 0) {
+                        var ra = parseInt(resp.headers.get('Retry-After'), 10);
+                        setTimeout(function () { attempt(retries - 1); }, (isNaN(ra) ? 3 : ra) * 1000); return;
+                    }
+                    if (!resp.ok) { reject(new Error('GET ' + path + ' -> HTTP ' + resp.status)); return; }
+                    resp.json().then(resolve, function () { reject(new Error('GET ' + path + ' -> non-JSON (HTTP ' + resp.status + ', ' + (resp.headers.get('content-type') || '?') + '); likely an unauthenticated response')); });
+                }, reject);
+            })(cfg.MAX_RETRIES);
+        });
+    }
+    // One page of /search/jql (retries mirror the tab's _apiPost: 429 only). Resolves the parsed response body.
+    function crSearch(jql, fields, token) {
+        var body = { jql: jql, fields: fields, maxResults: crc.PAGE_SIZE };
+        if (token) { body.nextPageToken = token; }
+        return new Promise(function (resolve, reject) {
+            (function attempt(retries) {
+                fetch(cfg.HOST + '/rest/api/3/search/jql', {
+                    method: 'POST', credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-Atlassian-Token': 'no-check' },
+                    body: JSON.stringify(body)
+                }).then(function (resp) {
+                    if (resp.status === 429 && retries > 0) {
+                        var ra = parseInt(resp.headers.get('Retry-After'), 10);
+                        setTimeout(function () { attempt(retries - 1); }, (isNaN(ra) ? 5 : ra) * 1000); return;
+                    }
+                    if (!resp.ok) { reject(new Error('search/jql -> HTTP ' + resp.status)); return; }
+                    resp.json().then(resolve, function () { reject(new Error('search/jql -> non-JSON (HTTP ' + resp.status + ', ' + (resp.headers.get('content-type') || '?') + '); likely an unauthenticated response')); });
+                }, reject);
+            })(cfg.MAX_RETRIES);
+        });
+    }
+    function crAccList(accounts) { return accounts.map(function (a) { return '"' + a + '"'; }).join(', '); }
+    function crSerial(items, fn) {
+        var out = [];
+        return items.reduce(function (p, item, i) { return p.then(function () { return fn(item, i); }).then(function (r) { out.push(r); }); }, Promise.resolve()).then(function () { return out; });
+    }
+    function crFetchIssues(jql, fields) {
+        var out = [];
+        function page(token) {
+            return crSearch(jql, fields, token).then(function (d) {
+                out = out.concat(d.issues || []);
+                var next = d.nextPageToken || null;
+                if (!next || d.isLast) { return out; }
+                return crSleep(cfg.PAGE_DELAY_MS).then(function () { return page(next); });
+            });
+        }
+        return page(null);
+    }
+    function crAllKeys(jql) {
+        return crFetchIssues(jql, ['key']).then(function (issues) { var keys = {}; for (var i = 0; i < issues.length; i++) { keys[issues[i].key] = true; } return keys; });
+    }
+    function crAllHistories(key) {
+        var out = [];
+        function page(start) {
+            return crGet('/rest/api/3/issue/' + key + '/changelog?startAt=' + start + '&maxResults=100').then(function (res) {
+                var vals = res.values || [];
+                out = out.concat(vals);
+                if (start + vals.length >= (res.total || 0) || !vals.length) { out.sort(function (a, b) { return (a.created || '') < (b.created || '') ? -1 : 1; }); return out; }
+                return page(start + vals.length);
+            });
+        }
+        return page(0);
+    }
+    function crGroupMembers(group) {
+        group = group || crc.GROUP;
+        var out = [];
+        function page(param, start) {
+            return crGet('/rest/api/3/group/member?' + param + '&includeInactiveUsers=true&startAt=' + start + '&maxResults=50').then(function (res) {
+                var vals = res.values || [];
+                out = out.concat(vals);
+                if (res.isLast || !vals.length) { return out; }
+                return page(param, start + vals.length);
+            });
+        }
+        return page('groupname=' + encodeURIComponent(group), 0).catch(function () {
+            return crGet('/rest/api/3/groups/picker?query=' + encodeURIComponent(group)).then(function (res) {
+                var gid = null, gs = (res && res.groups) || [];
+                for (var i = 0; i < gs.length; i++) { if ((gs[i].name || '').toLowerCase() === group.toLowerCase()) { gid = gs[i].groupId; } }
+                if (!gid) { throw new Error('group not found: ' + group); }
+                out = [];
+                return page('groupId=' + encodeURIComponent(gid), 0);
+            });
+        });
+    }
+    function crHandles(member) {
+        var out = [], seen = {};
+        var email = member.emailAddress || '';
+        if (email.indexOf('@') > 0) { out.push(email.split('@')[0]); }
+        var dn = (member.displayName || '').replace(/^\s+|\s+$/g, '');
+        var norm = /^isd /i.test(dn) ? dn.slice(4) : dn;
+        out.push(norm.replace(/ /g, '').toLowerCase());
+        out.push(norm.split(' ')[0].toLowerCase());
+        var uniq = [];
+        for (var i = 0; i < out.length; i++) { var h = out[i]; if (h && !seen[h]) { seen[h] = true; uniq.push(h); } }
+        return uniq;
+    }
+    function crReporterAccount(value) {
+        return crSearch('reporter = "' + value + '"', ['reporter'], null).then(function (d) {
+            var issues = d.issues || [];
+            if (!issues.length) { return ''; }
+            return ((issues[0].fields || {}).reporter || {}).accountId || '';
+        }, function () { return null; });
+    }
+    function crResolveOldReporters(members) {
+        var claimed = {}, oldIds = {}, oldNames = {};
+        return crSerial(members, function (m, i) {
+            crTick(i, members.length, 'resolving members: ' + (i + 1) + '/' + members.length);
+            var dn = m.displayName || m.accountId;
+            var cands = crHandles(m).map(function (h) { return h + '@' + crc.OLD_DOMAIN; });
+            return crSerial(cands, function (cand) {
+                if (claimed[cand]) { return null; }
+                return crReporterAccount(cand).then(function (aid) { return aid === null ? null : { cand: cand, aid: aid }; });
+            }).then(function (results) {
+                for (var k = 0; k < results.length; k++) {
+                    var hit = results[k];
+                    if (hit) { claimed[hit.cand] = true; if (hit.aid) { oldIds[hit.aid] = true; oldNames[hit.aid] = dn; } break; }
+                }
+            });
+        }).then(function () { return { oldIds: oldIds, oldNames: oldNames }; });
+    }
+    function crMonthBounds(y, m) {
+        var ny = m === 12 ? y + 1 : y, nm = m === 12 ? 1 : m + 1;
+        var p2 = function (n) { return (n < 10 ? '0' : '') + n; };
+        return { start: y + '-' + p2(m) + '-01', end: ny + '-' + p2(nm) + '-01' };
+    }
+    function crCreditFormula(r) {
+        var filtered = r.attached + r.trashed;
+        var c = 0.3 * Math.min(100, filtered) + 0.1 * Math.max(0, filtered - 100);
+        c += 0.1 * r.reassigned + r.created + r.resolved;
+        return Math.round(c * 10) / 10;
+    }
+    function crDefectsCreated(accounts, b, acctToName, rows) {
+        var jql = 'project in (' + crc.PROJECTS + ') AND issuetype = Defect ' +
+            'AND reporter in (' + crAccList(accounts) + ') ' +
+            'AND created >= "' + b.start + '" AND created < "' + b.end + '" ' +
+            'AND (resolution is EMPTY OR resolution != Duplicate)';
+        return crFetchIssues(jql, ['reporter', 'project']).then(function (issues) {
+            for (var i = 0; i < issues.length; i++) { var name = acctToName[((issues[i].fields || {}).reporter || {}).accountId]; if (name) { rows[name].created++; } }
+        });
+    }
+    function crDefectsResolved(accounts, b, acctToName, rows) {
+        var jql = 'project in (' + crc.PROJECTS + ') AND issuetype = Defect ' +
+            'AND reporter in (' + crAccList(accounts) + ') ' +
+            'AND resolution in (' + crc.RESOLUTIONS + ') ' +
+            'AND resolved >= "' + b.start + '" AND resolved < "' + b.end + '"';
+        return crFetchIssues(jql, ['reporter', 'project', 'issuelinks']).then(function (issues) {
+            var present = {}, meta = {};
+            for (var i = 0; i < issues.length; i++) { present[issues[i].key] = true; meta[issues[i].key] = issues[i]; }
+            var parent = {};
+            function find(x) { if (parent[x] === undefined) { parent[x] = x; } while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; }
+            function union(a, c) { var ra = find(a), rb = find(c); if (ra !== rb) { parent[ra] = rb; } }
+            for (var k in present) { if (present.hasOwnProperty(k)) { find(k); } }
+            for (var j = 0; j < issues.length; j++) {
+                var links = (issues[j].fields || {}).issuelinks || [];
+                for (var l = 0; l < links.length; l++) {
+                    if (!crc.DEDUP_LINK_TYPES[(links[l].type || {}).name]) { continue; }
+                    var other = links[l].inwardIssue || links[l].outwardIssue;
+                    if (other && present[other.key]) { union(issues[j].key, other.key); }
+                }
+            }
+            function rank(key) { var pk = (meta[key].fields.project || {}).key; var pr = crc.PROJECT_RANK[pk]; return (pr === undefined ? 99 : pr); }
+            var comps = {};
+            for (var kk in present) { if (present.hasOwnProperty(kk)) { var root = find(kk); (comps[root] = comps[root] || []).push(kk); } }
+            for (var root2 in comps) {
+                if (!comps.hasOwnProperty(root2)) { continue; }
+                var keep = comps[root2][0];
+                for (var q = 1; q < comps[root2].length; q++) {
+                    var cand = comps[root2][q];
+                    if (rank(cand) < rank(keep) || (rank(cand) === rank(keep) && cand < keep)) { keep = cand; }
+                }
+                var name = acctToName[((meta[keep].fields || {}).reporter || {}).accountId];
+                if (name) { rows[name].resolved++; }
+            }
+        });
+    }
+    function crIsAutomation(author) {
+        if (!author) { return false; }
+        if (crc.AUTOMATION_ID && author.accountId === crc.AUTOMATION_ID) { return true; }
+        if ((author.emailAddress || '').toLowerCase() === crc.AUTOMATION_EMAIL.toLowerCase()) { return true; }
+        return (author.displayName || '').toLowerCase().indexOf('automation for jira') !== -1;
+    }
+    function crAssigneeAt(histories, ts) {
+        var who = null;
+        for (var i = 0; i < histories.length; i++) {
+            if ((histories[i].created || '') > ts) { break; }
+            var items = histories[i].items || [];
+            for (var j = 0; j < items.length; j++) { if (items[j].field === 'assignee') { who = items[j].to; } }
+        }
+        return who;
+    }
+    function crEffectiveActioner(histories, targetStatus, b) {
+        var last = null;
+        for (var i = 0; i < histories.length; i++) {
+            var items = histories[i].items || [];
+            for (var j = 0; j < items.length; j++) {
+                if (items[j].field !== 'status') { continue; }
+                last = items[j].toString === targetStatus ? histories[i] : null;
+            }
+        }
+        if (!last) { return null; }
+        var created = last.created || '';
+        if (!(b.start <= created.slice(0, 10) && created.slice(0, 10) < b.end)) { return null; }
+        var author = last.author || {};
+        return crIsAutomation(author) ? crAssigneeAt(histories, created) : author.accountId;
+    }
+    function crReportsActioned(memberAccounts, b, rows, acctToName) {
+        var names = Object.keys(memberAccounts).sort();
+        var win = 'DURING ("' + b.start + '", "' + b.end + '")';
+        var movedOut = {};
+        return crAllKeys('project = ' + crc.EBR + ' AND status CHANGED FROM "' + crc.ATTACHED_STATUS + '" ' + win).then(function (a) {
+            return crAllKeys('project = ' + crc.EBR + ' AND status CHANGED FROM "' + crc.CLOSED_STATUS + '" ' + win).then(function (c) {
+                var k; for (k in a) { if (a.hasOwnProperty(k)) { movedOut[k] = true; } }
+                for (k in c) { if (c.hasOwnProperty(k)) { movedOut[k] = true; } }
+            });
+        }).then(function () {
+            return crSerial(names, function (name, i) {
+                crTick(i, names.length, 'reports: member ' + (i + 1) + '/' + names.length + '  (' + name + ')');
+                var accs = memberAccounts[name];
+                var att = {}, clo = {}, queries = [];
+                for (var qi = 0; qi < accs.length; qi++) {
+                    queries.push({ tgt: att, jql: 'project = ' + crc.EBR + ' AND status CHANGED TO "' + crc.ATTACHED_STATUS + '" BY "' + accs[qi] + '" ' + win });
+                    queries.push({ tgt: clo, jql: 'project = ' + crc.EBR + ' AND status CHANGED TO "' + crc.CLOSED_STATUS + '" BY "' + accs[qi] + '" ' + win });
+                }
+                if (crc.AUTOMATION_ID) {
+                    var who = 'assignee in (' + crAccList(accs) + ')';
+                    queries.push({ tgt: att, jql: 'project = ' + crc.EBR + ' AND status CHANGED TO "' + crc.ATTACHED_STATUS + '" BY "' + crc.AUTOMATION_ID + '" ' + win + ' AND ' + who });
+                    queries.push({ tgt: clo, jql: 'project = ' + crc.EBR + ' AND status CHANGED TO "' + crc.CLOSED_STATUS + '" BY "' + crc.AUTOMATION_ID + '" ' + win + ' AND ' + who });
+                }
+                return crSerial(queries, function (qq) {
+                    return crAllKeys(qq.jql).then(function (keys) { for (var kk in keys) { if (keys.hasOwnProperty(kk)) { qq.tgt[kk] = true; } } });
+                }).then(function () {
+                    var a = 0, cc = 0;
+                    for (var kA in att) { if (att.hasOwnProperty(kA) && !movedOut[kA]) { a++; } }
+                    for (var kC in clo) { if (clo.hasOwnProperty(kC) && !movedOut[kC]) { cc++; } }
+                    rows[name].attached += a;
+                    rows[name].trashed += cc;
+                });
+            });
+        }).then(function () {
+            var movedKeys = Object.keys(movedOut);
+            if (movedKeys.length) { crProgress('resolving ' + movedKeys.length + ' moved-out report(s) via changelog…'); }
+            return crSerial(movedKeys, function (k, i) {
+                crTick(i, movedKeys.length, 'moved-out reports: ' + (i + 1) + '/' + movedKeys.length);
+                return crSleep(crc.CRAWL_DELAY_MS).then(function () { return crAllHistories(k); }).then(function (hist) {
+                    var an = acctToName[crEffectiveActioner(hist, crc.ATTACHED_STATUS, b)];
+                    var cn = acctToName[crEffectiveActioner(hist, crc.CLOSED_STATUS, b)];
+                    if (an) { rows[an].attached += 1; }
+                    if (cn) { rows[cn].trashed += 1; }
+                });
+            });
+        });
+    }
+    function crAutoReassigned(b, acctToName, rows) {
+        var jql = 'project = ' + crc.EBR + ' AND ' + crc.TEAM_JQL + ' = ' + crc.GM_TEAM_ID + ' AND updated >= "' + b.start + '"';
+        return crAllKeys(jql).then(function (keySet) {
+            var keys = Object.keys(keySet);
+            crProgress('reassign: crawling ' + keys.length + ' candidate report(s)…');
+            return crSerial(keys, function (k, i) {
+                crTick(i, keys.length, 'reassign: ' + (i + 1) + '/' + keys.length);
+                return crSleep(crc.CRAWL_DELAY_MS).then(function () {
+                    return crGet('/rest/api/3/issue/' + k + '?expand=changelog&fields=summary');
+                }).then(function (issue) {
+                    var credited = {};
+                    var hist = ((issue.changelog || {}).histories) || [];
+                    for (var h = 0; h < hist.length; h++) {
+                        var created = (hist[h].created || '').slice(0, 10);
+                        if (!(b.start <= created && created < b.end)) { continue; }
+                        var items = hist[h].items || [];
+                        for (var j = 0; j < items.length; j++) {
+                            var it = items[j];
+                            var isTeam = it.fieldId === crc.TEAM_CF || it.field === 'Team';
+                            var isGm = it.to === crc.GM_TEAM_ID || it.to === crc.GM_TEAM_FULL_ID || it.toString === crc.GM_TEAM_NAME;
+                            if (isTeam && isGm) {
+                                var author = (hist[h].author || {}).accountId;
+                                if (author && !credited[author]) {
+                                    credited[author] = true;
+                                    var name = acctToName[author];
+                                    if (name) { rows[name].reassigned += 1; }
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+        }).catch(function (e) {
+            crProgress('reassign crawl skipped (' + ((e && e.message) || e) + ')');
+        });
+    }
+    function crComputeExtra(names, mentor) {
+        var out = {};
+        for (var i = 0; i < names.length; i++) {
+            var n = names[i];
+            var toks = {}; n.toLowerCase().replace(/-/g, ' ').split(/\s+/).forEach(function (t) { if (t) { toks[t] = true; } });
+            var e = 0;
+            for (var lead in crc.LEADS) { if (crc.LEADS.hasOwnProperty(lead) && toks[lead]) { e += crc.LEAD_BONUS; } }
+            if (mentor) { for (var hh in mentor) { if (mentor.hasOwnProperty(hh) && toks[hh]) { e += mentor[hh]; } } }
+            if (e) { out[n] = e; }
+        }
+        return out;
+    }
+    // Full per-member credit table for (y, m). Mirrors JiTA.credits._computeMonthLocal; resolves the same shape.
+    function crComputeMonth(payload) {
+        payload = payload || {};
+        var y = payload.y, m = payload.m, mentor = payload.mentor || null;
+        var b = crMonthBounds(y, m), ym = b.start.slice(0, 7);
+        crProgress(ym + ': resolving group members…');
+        return crGroupMembers().then(function (members) {
+            var active = members.filter(function (x) { return x.active !== false; });
+            return crResolveOldReporters(active).then(function (old) {
+                var acctToName = {}, memberAccounts = {}, nameToAcc = {};
+                active.forEach(function (x) {
+                    acctToName[x.accountId] = x.displayName;
+                    (memberAccounts[x.displayName] = memberAccounts[x.displayName] || []).push(x.accountId);
+                    if (!nameToAcc[x.displayName]) { nameToAcc[x.displayName] = x.accountId; }
+                });
+                for (var oid in old.oldNames) {
+                    if (!old.oldNames.hasOwnProperty(oid)) { continue; }
+                    var nm = old.oldNames[oid];
+                    acctToName[oid] = nm;
+                    (memberAccounts[nm] = memberAccounts[nm] || []).push(oid);
+                }
+                var names = Object.keys(memberAccounts).sort();
+                var rows = {};
+                names.forEach(function (n) { rows[n] = { created: 0, resolved: 0, attached: 0, trashed: 0, reassigned: 0 }; });
+                var allAccounts = Object.keys(acctToName);
+                crProgress(ym + ': ' + names.length + ' members - fetching defects…');
+                return crDefectsCreated(allAccounts, b, acctToName, rows)
+                    .then(function () { return crDefectsResolved(allAccounts, b, acctToName, rows); })
+                    .then(function () { crProgress(ym + ': reports (attached / trashed)…'); return crReportsActioned(memberAccounts, b, rows, acctToName); })
+                    .then(function () { crProgress(ym + ': reassignments to GM…'); return crAutoReassigned(b, acctToName, rows); })
+                    .then(function () {
+                        var extras = crComputeExtra(names, mentor);
+                        var header = ['Name', 'Defects Created', 'Defects Resolved', 'Reports Attached',
+                            'Reports Trashed', 'Reports Reassigned', 'Total Actioned', 'Extra Credits', 'Credits Earned'];
+                        var table = [];
+                        var tot = { created: 0, resolved: 0, attached: 0, trashed: 0, reassigned: 0, actioned: 0, extra: 0, credits: 0 };
+                        names.forEach(function (n) {
+                            var r = rows[n], extra = extras[n] || 0;
+                            var actioned = r.attached + r.trashed + r.reassigned + r.created;
+                            var earned = crCreditFormula(r);
+                            table.push([n, r.created, r.resolved, r.attached, r.trashed, r.reassigned, actioned, extra, earned]);
+                            tot.created += r.created; tot.resolved += r.resolved; tot.attached += r.attached;
+                            tot.trashed += r.trashed; tot.reassigned += r.reassigned; tot.actioned += actioned;
+                            tot.extra += extra; tot.credits += earned;
+                        });
+                        table.push(['Total', tot.created, tot.resolved, tot.attached, tot.trashed, tot.reassigned,
+                            tot.actioned, Math.round(tot.extra * 10) / 10, Math.round(tot.credits * 10) / 10]);
+                        return { ym: ym, computedAt: new Date().toISOString(), header: header, table: table, rows: rows, nameToAcc: nameToAcc, memberAccounts: memberAccounts };
+                    });
+            });
+        });
+    }
+    // Single-flight so two tabs (e.g. a scheduled run + a manual Refresh) never crawl the same month at once:
+    // a same-month caller COALESCES onto the in-flight crawl (one crawl, one result, one clean progress stream for
+    // all of them); a different-month request is queued behind it. Without this, concurrent crawls doubled the REST
+    // load and their per-item progress ticks interleaved (counts jumping up then back down). crActiveTags is set at
+    // crawl START (not enqueue) so a queued run's progress can't be mis-tagged to a different pending run.
+    function runCreditsMonth(payload) {
+        payload = payload || {};
+        var key = payload.y + '-' + payload.m, tag = payload.tag || null;
+        if (crLast && crLast.key === key) {                                  // coalesce onto the most-recent same-month crawl
+            if (tag && crLast.tags.indexOf(tag) === -1) { crLast.tags.push(tag); }
+            return crLast.promise;
+        }
+        var prev = crLast ? crLast.promise : Promise.resolve();
+        var run = { key: key, tags: tag ? [tag] : [], promise: null };
+        var begin = function () { crActiveTags = run.tags; return crComputeMonth(payload); };
+        run.promise = prev.then(begin, begin);                               // queue behind any running/queued crawl (never concurrent)
+        crLast = run;
+        var settle = function () { if (crLast === run) { crLast = null; } if (crActiveTags === run.tags) { crActiveTags = []; } };
+        run.promise.then(settle, settle);
+        return run.promise;
+    }
+
+    self.onmessage = async function (e) {
+        var d = e.data || {}, id = d.id, type = d.type, payload = d.payload;
+        try {
+            var result;
+            if (type === 'ping') { result = { pong: true, backend: backend }; }
+            else if (type === 'embed') { var v = await embed((payload && payload.text) || ''); result = { backend: backend, dim: v.length, vec: Array.from(v) }; }
+            else if (type === 'rankSemantic') { result = await rankSemantic(payload); }
+            else if (type === 'rankKeyword') { result = await rankKeyword(payload); }
+            else if (type === 'logsig') {
+                await ensureIndexes();
+                var op = payload && payload.op;
+                if (op === 'siblings') { result = lgSiblings(payload.key); }
+                else if (op === 'related') { result = lgRelated(payload.key); }
+                else if (op === 'clusters') { result = lgClusters(); }
+                else if (op === 'match') { result = lgMatch(payload.text); }
+                else { throw new Error('unknown logsig op: ' + op); }
+            }
+            else if (type === 'embedPass') {
+                // Long-running (minutes on a full rebuild): ACK immediately so the caller's RPC never times out,
+                // and post an 'embedPassDone' event when the background pass actually finishes.
+                if (embedding) { result = { started: false, busy: true }; }
+                else {
+                    embedPass().then(function (rr) { self.postMessage({ event: 'embedPassDone', embedded: (rr && rr.embedded) || 0 }); },
+                        function (er) { self.postMessage({ event: 'embedPassError', error: String((er && er.message) || er) }); });
+                    result = { started: true };
+                }
+            }
+            else if (type === 'creditsMonth') {
+                // Long-running (minutes): the caller passes a big timeout. runCreditsMonth single-flights + coalesces
+                // so two tabs never crawl the same month at once; progress streams as tagged 'creditsProgress' events.
+                result = await runCreditsMonth(payload);
+            }
+            else if (type === 'invalidate') { vecCache = null; kwCache = null; logsigCache = null; result = { ok: true }; }   // drop all indexes after a sync writes the DB
+            else { throw new Error('unknown worker request: ' + type); }
+            self.postMessage({ id: id, ok: true, result: result });
+        } catch (err) { self.postMessage({ id: id, ok: false, error: String((err && err.message) || err), stack: String((err && err.stack) || '') }); }
+    };
+}
+
+
+/* ---- shared ranking worker: one model+index for ALL tabs instead of one per tab -----------------------
+ * A userscript can't host a same-origin SharedWorker script (blob/data-URL SharedWorkers don't share across
+ * tabs), so we get the same "one instance for everyone" outcome from primitives that DO work: one tab is
+ * elected LEADER via the Web Locks API and owns a single dedicated module worker; every tab talks to the
+ * leader over a BroadcastChannel. The worker (built from a blob) imports transformers.js, opens the same-origin
+ * IndexedDB (pristine in a worker - Atlassian's consent gate only wraps the main document), holds the model +
+ * ranking indexes, and answers rank queries. Tabs become thin clients. Feature-flagged and additive: nothing
+ * calls into it yet (this milestone just proves leader election + RPC + a shared worker across tabs).
+ */
+JiTA.worker = {
+    CHANNEL: 'jita-rank-v1',
+    LOCK: 'jita-rank-leader-v1',
+    RPC_TIMEOUT_MS: 30000,
+
+    _bc: null,           // BroadcastChannel (every tab)
+    _worker: null,       // the dedicated Worker (leader only)
+    _isLeader: false,
+    _started: false,
+    _tabPending: {},     // id -> {resolve,reject,timer}  : channel requests THIS tab is awaiting
+    _tabSeq: 0,
+    _wPending: {},       // id -> {resolve,reject,timer}  : worker requests the LEADER is awaiting
+    _wSeq: 0,
+
+    start: function () {
+        if (JiTA.worker._started || JITA_IS_FORGE_FRAME) { return; }
+        JiTA.worker._started = true;
+        try { JiTA.worker._bc = new BroadcastChannel(JiTA.worker.CHANNEL); JiTA.worker._bc.onmessage = JiTA.worker._onBc; } catch (e) { /* no channel -> leader-only */ }
+        // Elect a single leader: hold an exclusive Web Lock for this tab's lifetime. When the leader tab closes
+        // the lock releases and another tab's pending request wins -> it becomes leader and spawns its worker.
+        try {
+            if (navigator.locks && navigator.locks.request) {
+                navigator.locks.request(JiTA.worker.LOCK, function () {
+                    JiTA.worker._becomeLeader();
+                    return new Promise(function () { /* never resolve: hold the lock until the tab is gone */ });
+                });
+            } else {
+                JiTA.worker._becomeLeader();   // no Web Locks -> degrade to a per-tab worker
+            }
+        } catch (e) { if (window.console) { console.log('[JiTA worker] leader election failed:', e); } }
+    },
+
+    _becomeLeader: function () {
+        if (JiTA.worker._isLeader) { return; }
+        JiTA.worker._isLeader = true;
+        try {
+            var url = URL.createObjectURL(new Blob([JiTA.worker._src()], { type: 'text/javascript' }));
+            JiTA.worker._worker = new Worker(url, { type: 'module' });
+            JiTA.worker._worker.onmessage = JiTA.worker._onWorker;
+            JiTA.worker._worker.onerror = function (e) { if (window.console) { console.log('[JiTA worker] worker error:', (e && e.message) || e); } };
+            setTimeout(function () { try { URL.revokeObjectURL(url); } catch (x) { /* ignore */ } }, 15000);   // keep the URL alive long enough for the worker to load its module
+            if (window.console) { console.log('[JiTA worker] this tab is now the ranking LEADER (worker spawned)'); }
+            // Embed anything outstanding in the worker (also warms the model there for ranking). Delayed so it
+            // doesn't compete with first paint. Single-flight in the worker, so a concurrent prepare() is harmless.
+            setTimeout(function () {
+                JiTA.worker._workerCall('embedPass').then(function (r) {
+                    if (r && r.embedded > 0) { if (window.console) { console.log('[JiTA worker] embed pass: ' + r.embedded + ' embedded'); } try { JiTA.ui.scheduleRender(); } catch (e) { /* ignore */ } }
+                }, function () { /* ignore */ });
+            }, 8000);
+        } catch (e) { JiTA.worker._isLeader = false; if (window.console) { console.log('[JiTA worker] worker spawn failed:', e); } }
+    },
+
+    // Public: call the ranking worker from ANY tab. Resolves with the worker's result (or rejects on timeout /
+    // no leader). Leader shortcuts straight to its worker; followers route over the channel.
+    call: function (type, payload, opts) {
+        opts = opts || {};
+        var timeoutMs = opts.timeoutMs || JiTA.worker.RPC_TIMEOUT_MS;   // long crawls (credits) pass a bigger cap
+        if (JiTA.worker._isLeader && JiTA.worker._worker) { return JiTA.worker._workerCall(type, payload, timeoutMs); }
+        return new Promise(function (resolve, reject) {
+            if (!JiTA.worker._bc) { reject(new Error('no leader / no channel')); return; }
+            var id = (JiTA.sched.tabId) + ':' + (++JiTA.worker._tabSeq);
+            var timer = setTimeout(function () { delete JiTA.worker._tabPending[id]; reject(new Error('rpc timeout (no leader ready?)')); }, timeoutMs);
+            JiTA.worker._tabPending[id] = { resolve: resolve, reject: reject, timer: timer };
+            JiTA.worker._bc.postMessage({ kind: 'req', id: id, type: type, payload: payload, timeoutMs: timeoutMs });
+        });
+    },
+
+    // Leader <-> its worker
+    _workerCall: function (type, payload, timeoutMs) {
+        return new Promise(function (resolve, reject) {
+            if (!JiTA.worker._worker) { reject(new Error('no worker')); return; }
+            var id = ++JiTA.worker._wSeq;
+            var timer = setTimeout(function () { delete JiTA.worker._wPending[id]; reject(new Error('worker timeout')); }, timeoutMs || JiTA.worker.RPC_TIMEOUT_MS);
+            JiTA.worker._wPending[id] = { resolve: resolve, reject: reject, timer: timer };
+            JiTA.worker._worker.postMessage({ id: id, type: type, payload: payload });
+        });
+    },
+    _onWorker: function (e) {
+        var d = e.data || {};
+        if (d.event) { JiTA.worker._relayEvent(d); return; }   // unsolicited worker event (e.g. embed pass finished)
+        var p = JiTA.worker._wPending[d.id];
+        if (!p) { return; }
+        clearTimeout(p.timer); delete JiTA.worker._wPending[d.id];
+        if (d.ok) { p.resolve(d.result); } else { p.reject(new Error(d.error || 'worker error')); }
+    },
+    // The leader relays a worker event to every tab (over the channel) and applies it locally.
+    _relayEvent: function (d) {
+        try { if (JiTA.worker._bc) { JiTA.worker._bc.postMessage({ kind: 'event', data: d }); } } catch (e) { /* ignore */ }
+        JiTA.worker._applyEvent(d);
+    },
+    _applyEvent: function (d) {
+        if (!d) { return; }
+        if (d.event === 'embedPassDone' && d.embedded > 0) {
+            if (window.console) { console.log('[JiTA worker] embed pass finished: ' + d.embedded + ' embedded'); }
+            try { JiTA.ui.scheduleRender(); } catch (e) { /* ignore */ }   // re-rank the open view now the new vectors exist
+            return;
+        }
+        // Credits crawl progress from the worker. Broadcast to every tab, but only the tab that started THIS
+        // crawl (matching tag) shows its pill; the rest ignore it. _pill itself no-ops during quiet background runs.
+        if (d.event === 'creditsProgress') {
+            // Accept both the new tags[] shape and the legacy single tag, so a not-yet-reloaded leader worker (version
+            // skew during a script update) still drives this tab's pill instead of silently blanking it.
+            var wt = JiTA.credits && JiTA.credits._workerTag;
+            if (wt && ((d.tags && d.tags.indexOf(wt) !== -1) || (d.tag && d.tag === wt))) { try { JiTA.credits._pill(d.msg); } catch (e) { /* ignore */ } }
+            return;
+        }
+    },
+
+    // Channel handler: leaders service 'req' (forward to worker, broadcast 'res'); every tab matches 'res'.
+    _onBc: function (e) {
+        var m = e.data || {};
+        if (m.kind === 'req') {
+            if (!JiTA.worker._isLeader || !JiTA.worker._worker) { return; }   // only the leader answers
+            JiTA.worker._workerCall(m.type, m.payload, m.timeoutMs).then(function (result) {
+                JiTA.worker._bc.postMessage({ kind: 'res', id: m.id, ok: true, result: result });
+            }, function (err) {
+                JiTA.worker._bc.postMessage({ kind: 'res', id: m.id, ok: false, error: String((err && err.message) || err) });
+            });
+        } else if (m.kind === 'res') {
+            var p = JiTA.worker._tabPending[m.id];
+            if (!p) { return; }
+            clearTimeout(p.timer); delete JiTA.worker._tabPending[m.id];
+            if (m.ok) { p.resolve(m.result); } else { p.reject(new Error(m.error || 'remote error')); }
+        } else if (m.kind === 'event') {
+            JiTA.worker._applyEvent(m.data);   // a worker event the leader relayed (e.g. embed pass finished)
+        }
+    },
+
+    // The dedicated worker's source (a module). Minimal for this milestone: lazy-load the model, answer 'ping'
+    // and 'embed'. Later milestones add the vector/keyword indexes + ranking here and return just ranked keys.
+    // The worker source: the real jitaWorkerBody function, serialized + immediately invoked with runtime config.
+    _src: function () {
+        var C = JiTA.credits;
+        var cfg = {
+            LIB: JiTA.embed.LIB_URL, MODEL: JiTA.embed.MODEL, MODEL_VERSION: JiTA.MODEL_VERSION,
+            DB_NAME: JiTA.DB_NAME, DB_VERSION: JiTA.DB_VERSION, MAX_CHARS: JiTA.embed.MAX_CHARS, GM_TEAM_ID: JiTA.GM_TEAM_ID,
+            tryGpu: gmGet('sdTryWebgpu', true) && !gmGet('sdForceCpu', false),
+            HOST: JiTA.HOST, MAX_RETRIES: JiTA.MAX_RETRIES, PAGE_DELAY_MS: JiTA.PAGE_DELAY_MS,
+            // ISD credits config (mirror of JiTA.credits' static fields) so the worker can run the monthly crawl.
+            credits: {
+                PROJECTS: C.PROJECTS, RESOLUTIONS: C.RESOLUTIONS, GROUP: C.GROUP, OLD_DOMAIN: C.OLD_DOMAIN,
+                EBR: C.EBR, ATTACHED_STATUS: C.ATTACHED_STATUS, CLOSED_STATUS: C.CLOSED_STATUS,
+                TEAM_JQL: C.TEAM_JQL, TEAM_CF: C.TEAM_CF, GM_TEAM_ID: C.GM_TEAM_ID, GM_TEAM_FULL_ID: C.GM_TEAM_FULL_ID,
+                GM_TEAM_NAME: C.GM_TEAM_NAME, AUTOMATION_ID: C.AUTOMATION_ID, AUTOMATION_EMAIL: C.AUTOMATION_EMAIL,
+                DEDUP_LINK_TYPES: C.DEDUP_LINK_TYPES, PROJECT_RANK: C.PROJECT_RANK, LEADS: C.LEADS, LEAD_BONUS: C.LEAD_BONUS,
+                PAGE_SIZE: C.PAGE_SIZE, CRAWL_DELAY_MS: C.CRAWL_DELAY_MS
+            }
+        };
+        return '(' + jitaWorkerBody.toString() + ')(' + JSON.stringify(cfg) + ');';
+    }
+};
+
+
 /* ---- init: watch the DOM and (re)inject the panel across Atlassian's React re-renders / SPA nav ---- */
 (function () {
     if (JITA_IS_FORGE_FRAME) { return; }  // inside the Zendesk Forge iframe we only run the responses dropdown
@@ -8716,6 +9623,8 @@ JiTA.credits = {
     }
     // start the periodic background catch-up sync
     JiTA.sched.start();
+    // Shared ranking worker: elect a leader + spawn the one worker all tabs share (additive; nothing routes to it yet).
+    try { JiTA.worker.start(); } catch (e) { /* swallow */ }
     // ISD credit tracker: show the corner badge (from cache) and start the throttled background recompute.
     if (savedVariables[3][1]) {
         try { JiTA.credits.badge.mount(); } catch (e) { /* swallow */ }

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -8470,13 +8470,23 @@ JiTA.credits = {
             var $wrap = $('<div style="overflow-x:auto;"></div>');
             var $tbl = $('<table style="border-collapse:collapse;font-size:12px;width:100%;"></table>');
             var $thead = $('<thead></thead>');
-            // grouping row: which columns are DEFECTS (Created/Resolved) vs BUG REPORTS (Attached/Trashed/Reassigned)
-            var thg = 'padding:4px 8px;border-bottom:1px solid #2c333a;color:#7a8694;font-size:11px;text-transform:uppercase;letter-spacing:.04em;text-align:center;';
+            // grouping row: DEFECTS (Created/Resolved) vs BUG REPORTS (Attached/Trashed/Reassigned). The caption +
+            // its underline live in an INSET div, so each group's underline is separated by a gap (adjacent <th>
+            // bottom-borders would otherwise merge into one long line) and the label is centred over its columns.
             var $g = $('<tr></tr>');
-            $('<th colspan="2"></th>').appendTo($g);                                        // # + Name
-            $('<th colspan="2"></th>').attr('style', thg).text('Defects').appendTo($g);      // Created + Resolved
-            $('<th colspan="3"></th>').attr('style', thg).text('Bug reports').appendTo($g);  // Attached + Trashed + Reassigned
-            $('<th colspan="2"></th>').appendTo($g);                                        // Actioned + Credits
+            function grpCell(colspan, label) {
+                var $th = $('<th colspan="' + colspan + '"></th>');
+                if (label) {
+                    $('<div></div>').attr('style', 'margin:0 16px;padding-bottom:4px;border-bottom:1px solid #4a5560;' +
+                        'text-align:center;color:#8a94a0;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;')
+                        .text(label).appendTo($th);
+                }
+                return $th;
+            }
+            $g.append(grpCell(2, ''));             // # + Name
+            $g.append(grpCell(2, 'Defects'));      // Created + Resolved
+            $g.append(grpCell(3, 'Bug reports'));  // Attached + Trashed + Reassigned
+            $g.append(grpCell(2, ''));             // Actioned + Credits
             $thead.append($g);
             // label row
             var $hr = $('<tr></tr>');

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -199,7 +199,7 @@ if (!JITA_IS_FORGE_FRAME) {
         if (typeof JiTA !== 'undefined' && JiTA.menu) { JiTA.menu.open(); }
     });
     // Open the ISD Credits overlay (your live monthly total + the leads-only leaderboard). The overlay's
-    // Refresh recomputes the selected month and also dumps the table to the console (verify vs. monthly_report.py).
+    // Refresh recomputes the selected month's full leaderboard on demand.
     GM_registerMenuCommand("📊 ISD Credits leaderboard…", function () {
         if (typeof JiTA !== 'undefined' && JiTA.credits) { JiTA.credits.openView(); }
     });
@@ -7468,18 +7468,7 @@ JiTA.menu = {
                 JiTA.credits._quiet = false;
                 JiTA.credits.refresh(now.y, now.m).then(function () { JiTA.credits.badge.refresh(); }).catch(function () { /* ignore */ });
             }).appendTo($crAct);
-            // Auto-update interval: how often the current month is recomputed in the background (0 = manual only).
-            var $ivRow = $('<div class="jita-menu-row"></div>');
-            $('<span class="lbl">Auto-update</span>')
-                .append($('<span class="sub"></span>').text('How often to recompute this month in the background'))
-                .appendTo($ivRow);
-            var $iv = $('<select class="jita-cred-input" style="width:auto;"></select>');
-            [['Manual only', '0'], ['Every 5 minutes', '5'], ['Every 15 minutes', '15'], ['Every 30 minutes', '30'], ['Every hour', '60'], ['Every 3 hours', '180'], ['Every 6 hours', '360'], ['Every 12 hours', '720'], ['Every 24 hours', '1440']]
-                .forEach(function (o) { $('<option></option>').val(o[1]).text(o[0]).appendTo($iv); });
-            $iv.val(String(JiTA.credits.sched.intervalMin()));
-            $iv.on('change', function () { gmSet('creditsIntervalMin', parseInt($iv.val(), 10) || 0); });
-            $ivRow.append($iv);
-            $cr.append($ivRow);
+            $('<div class="jita-menu-status" style="margin-top:6px;color:#7a8694;">Your own total refreshes automatically every ~2 min; the full leaderboard every ~15 min.</div>').appendTo($cr);
             $p.append($cr);
         }
 
@@ -8205,7 +8194,7 @@ JiTA.credits = {
                         });
                         table.push(['Total', tot.created, tot.resolved, tot.attached, tot.trashed, tot.reassigned,
                             tot.actioned, Math.round(tot.extra * 10) / 10, Math.round(tot.credits * 10) / 10]);
-                        return { ym: ym, computedAt: new Date().toISOString(), header: header, table: table, rows: rows, nameToAcc: nameToAcc };
+                        return { ym: ym, computedAt: new Date().toISOString(), header: header, table: table, rows: rows, nameToAcc: nameToAcc, memberAccounts: memberAccounts };
                     });
             });
         });
@@ -8237,6 +8226,125 @@ JiTA.credits = {
             JiTA.credits.running = false;
             JiTA.credits._clearProgress();
             JiTA.ui.setStatus('Credits error: ' + (e && e.message || e));
+            throw e;
+        });
+    },
+
+    // ---- self-only compute (cheap; the badge / your card refresh on this every ~2 min) ------------------
+    // We recompute only the LOGGED-IN user's numbers frequently, and reuse the slow-changing Reassigned +
+    // Extra (and the rank basis) from the last full leaderboard run. This avoids the expensive group-wide
+    // reassignment crawl on the fast cadence, so the fast path is just a handful of self-scoped searches.
+    _selfKey: function (ym) { return 'creditsSelf:' + ym; },
+    getSelf: function (ym) { return JiTA.db.getMeta(JiTA.credits._selfKey(ym)); },
+
+    // Resolve the viewer's name + accounts (+ their cached Reassigned/Extra and the full table for ranking),
+    // preferring the last full-leaderboard cache; falls back to /myself + old-account resolution if there's none.
+    _selfIdentity: function (me, full) {
+        var C = JiTA.credits;
+        if (full && full.nameToAcc) {
+            var myName = null;
+            for (var n in full.nameToAcc) { if (full.nameToAcc.hasOwnProperty(n) && full.nameToAcc[n] === me) { myName = n; } }
+            if (myName) {
+                var myAccounts = (full.memberAccounts && full.memberAccounts[myName]) || [me];
+                var reassigned = (full.rows && full.rows[myName] && full.rows[myName].reassigned) || 0;
+                var extra = 0;
+                (full.table || []).forEach(function (row) { if (row[0] === myName) { extra = row[7] || 0; } });
+                return Promise.resolve({ myName: myName, myAccounts: myAccounts, reassigned: reassigned, extra: extra, fullTable: full.table });
+            }
+        }
+        return C._get('/rest/api/2/myself').then(function (mys) {
+            var myName = (mys && mys.displayName) || null;
+            return C._resolveOldReporters([{ accountId: me, displayName: myName, emailAddress: (mys && mys.emailAddress) || '' }]).then(function (old) {
+                var myAccounts = [me];
+                for (var oid in old.oldNames) { if (old.oldNames.hasOwnProperty(oid)) { myAccounts.push(oid); } }
+                var extra = myName ? (C._computeExtra([myName])[myName] || 0) : 0;
+                return { myName: myName, myAccounts: myAccounts, reassigned: 0, extra: extra, fullTable: null };
+            });
+        }, function () { return { myName: null, myAccounts: [me], reassigned: 0, extra: 0, fullTable: null }; });
+    },
+
+    // Attached / Trashed for MY accounts only. Same rules as _reportsActioned, but the reopen-aware changelog
+    // crawl is limited to the reports I TOUCHED that later moved out (a tiny set) instead of every moved-out report.
+    _reportsActionedSelf: function (accs, b) {
+        var C = JiTA.credits, win = 'DURING ("' + b.start + '", "' + b.end + '")';
+        var att = {}, clo = {}, queries = [];
+        for (var i = 0; i < accs.length; i++) {
+            queries.push({ tgt: att, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.ATTACHED_STATUS + '" BY "' + accs[i] + '" ' + win });
+            queries.push({ tgt: clo, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.CLOSED_STATUS + '" BY "' + accs[i] + '" ' + win });
+        }
+        if (C.AUTOMATION_ID) {
+            var who = 'assignee in (' + C._accList(accs) + ')';
+            queries.push({ tgt: att, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.ATTACHED_STATUS + '" BY "' + C.AUTOMATION_ID + '" ' + win + ' AND ' + who });
+            queries.push({ tgt: clo, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.CLOSED_STATUS + '" BY "' + C.AUTOMATION_ID + '" ' + win + ' AND ' + who });
+        }
+        var movedOut = {};
+        return C._allKeys('project = ' + C.EBR + ' AND status CHANGED FROM "' + C.ATTACHED_STATUS + '" ' + win).then(function (a) {
+            return C._allKeys('project = ' + C.EBR + ' AND status CHANGED FROM "' + C.CLOSED_STATUS + '" ' + win).then(function (c) {
+                var k; for (k in a) { if (a.hasOwnProperty(k)) { movedOut[k] = true; } }
+                for (k in c) { if (c.hasOwnProperty(k)) { movedOut[k] = true; } }
+            });
+        }).then(function () {
+            return C._serial(queries, function (q) { return C._allKeys(q.jql).then(function (keys) { for (var kk in keys) { if (keys.hasOwnProperty(kk)) { q.tgt[kk] = true; } } }); });
+        }).then(function () {
+            var attached = 0, trashed = 0, ambiguous = [];
+            for (var kA in att) { if (att.hasOwnProperty(kA)) { if (!movedOut[kA]) { attached++; } else { ambiguous.push({ k: kA, kind: 'att' }); } } }
+            for (var kC in clo) { if (clo.hasOwnProperty(kC)) { if (!movedOut[kC]) { trashed++; } else { ambiguous.push({ k: kC, kind: 'clo' }); } } }
+            var myAcc = {}; accs.forEach(function (a) { myAcc[a] = true; });
+            return C._serial(ambiguous, function (item) {
+                return JiTA.util.delay(C.CRAWL_DELAY_MS).then(function () { return C._allHistories(item.k); }).then(function (hist) {
+                    var status = item.kind === 'att' ? C.ATTACHED_STATUS : C.CLOSED_STATUS;
+                    var actioner = C._effectiveActioner(hist, status, b);
+                    if (actioner && myAcc[actioner]) { if (item.kind === 'att') { attached++; } else { trashed++; } }
+                });
+            }).then(function () { return { attached: attached, trashed: trashed }; });
+        });
+    },
+
+    // Compute + cache only the viewer's numbers for (y, m). Resolves the self record (also written to creditsSelf:<ym>).
+    computeSelf: function (y, m) {
+        var C = JiTA.credits, b = C._monthBounds(y, m), ym = b.start.slice(0, 7);
+        return JiTA.link.currentUser().then(function (me) {
+            if (!me) { return null; }
+            return C.getCached(ym).then(function (full) {
+                return C._selfIdentity(me, full).then(function (id) {
+                    if (!id.myName) { return null; }   // couldn't identify the viewer as a member
+                    var rows = {}; rows[id.myName] = { created: 0, resolved: 0, attached: 0, trashed: 0, reassigned: 0 };
+                    var acctToName = {}; id.myAccounts.forEach(function (a) { acctToName[a] = id.myName; });
+                    return C._defectsCreated(id.myAccounts, b, acctToName, rows)
+                        .then(function () { return C._defectsResolved(id.myAccounts, b, acctToName, rows); })
+                        .then(function () { return C._reportsActionedSelf(id.myAccounts, b); })
+                        .then(function (rep) {
+                            var r = rows[id.myName];
+                            r.attached = rep.attached; r.trashed = rep.trashed; r.reassigned = id.reassigned;
+                            var credits = C._creditFormula(r, id.extra);
+                            var actioned = r.attached + r.trashed + r.reassigned + r.created;
+                            var rank = null, total = null;
+                            if (id.fullTable) {
+                                var real = id.fullTable.slice(0, id.fullTable.length - 1);
+                                var better = 0;
+                                real.forEach(function (row) { var cv = (row[0] === id.myName) ? credits : row[8]; if (cv > credits) { better++; } });
+                                rank = better + 1; total = real.length;
+                            }
+                            var out = { ym: ym, computedAt: new Date().toISOString(), me: me, myName: id.myName,
+                                created: r.created, resolved: r.resolved, attached: r.attached, trashed: r.trashed,
+                                reassigned: r.reassigned, actioned: actioned, extra: id.extra, credits: credits, rank: rank, total: total };
+                            return JiTA.db.setMeta(C._selfKey(ym), out).then(function () { return out; });
+                        });
+                });
+            });
+        });
+    },
+
+    // Guarded self recompute (mirrors refresh): updates creditsSelf + the badge. Shares the single `running` flag.
+    refreshSelf: function (y, m) {
+        if (JiTA.credits.running) { return Promise.resolve(null); }
+        JiTA.credits.running = true;
+        return JiTA.credits.computeSelf(y, m).then(function (res) {
+            JiTA.credits.running = false;
+            try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }
+            return res;
+        }).catch(function (e) {
+            JiTA.credits.running = false;
             throw e;
         });
     },
@@ -8305,8 +8413,7 @@ JiTA.credits = {
             var p = sel.split('-'), yy = parseInt(p[0], 10), mm = parseInt(p[1], 10);
             $refresh.prop('disabled', true).text('Computing…');
             C._quiet = false;   // user-triggered: show the progress pill
-            C.refresh(yy, mm).then(function (res) {
-                if (res) { C._report(res); }   // also dump to console (verification)
+            C.refresh(yy, mm).then(function () {
                 C.badge.refresh();
                 $refresh.prop('disabled', false).text('Refresh');
                 render();
@@ -8316,35 +8423,67 @@ JiTA.credits = {
             });
         });
 
-        function card(res, d) {
-            var h = res.header;
+        // The viewer's line, preferring the fresher self cache (current month) over the full-leaderboard row.
+        function cardInfo(fullRes, selfRes, me) {
+            if (selfRes && selfRes.me === me && selfRes.credits != null) {
+                return { myName: selfRes.myName, created: selfRes.created, resolved: selfRes.resolved, attached: selfRes.attached,
+                    trashed: selfRes.trashed, reassigned: selfRes.reassigned, actioned: selfRes.actioned, extra: selfRes.extra,
+                    credits: selfRes.credits, rank: selfRes.rank, total: selfRes.total };
+            }
+            if (fullRes) {
+                var d = C._derive(fullRes, me);
+                if (d.myRow) {
+                    return { myName: d.myName, created: d.myRow[1], resolved: d.myRow[2], attached: d.myRow[3], trashed: d.myRow[4],
+                        reassigned: d.myRow[5], actioned: d.myRow[6], extra: d.myRow[7], credits: d.myRow[8], rank: d.myRank, total: d.total };
+                }
+            }
+            return { myName: null };
+        }
+
+        function card(info) {
             var $c = $('<div style="background:#22272b;border:1px solid #2c333a;border-radius:8px;padding:12px 14px;"></div>');
             $('<div style="font-weight:700;font-size:13px;margin-bottom:8px;"></div>')
-                .text(d.myName ? ('You - ' + d.myName) : 'Your account was not matched to an ECAID member').appendTo($c);
-            if (d.myRow) {
-                var bits = [];
-                for (var i = 1; i <= 6; i++) { bits.push(h[i].replace('Defects ', '').replace('Reports ', '') + ' ' + d.myRow[i]); }
-                $('<div style="color:#c7cdd4;font-size:12px;line-height:1.8;"></div>').text(bits.join('   ')).appendTo($c);
-                var $big = $('<div style="margin-top:8px;font-size:16px;font-weight:800;color:#fff;"></div>').text(d.myRow[8] + ' credits');
-                $('<span style="color:#9aa6b2;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('rank #' + d.myRank + ' of ' + d.total).appendTo($big);
-                if (d.myRow[7]) { $('<span style="color:#b794f6;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('(+' + d.myRow[7] + ' extra)').appendTo($big); }
-                $big.appendTo($c);
+                .text(info.myName ? ('You - ' + info.myName) : 'Your account was not matched to an ECAID member').appendTo($c);
+            if (info.myName && info.credits != null) {
+                // Two labelled groups so it's clear Created/Resolved are DEFECTS and Attached/Trashed/Reassigned are BUG REPORTS.
+                function group(label, parts) {
+                    var $l = $('<div style="font-size:12px;line-height:1.9;"></div>');
+                    $('<span style="color:#8a94a0;font-weight:700;"></span>').text(label).appendTo($l);
+                    parts.forEach(function (p) { $('<span style="color:#c7cdd4;margin-left:14px;"></span>').text(p).appendTo($l); });
+                    return $l;
+                }
+                $c.append(group('Defects', [info.created + ' created', info.resolved + ' resolved']));
+                $c.append(group('Bug reports', [info.attached + ' attached', info.trashed + ' trashed', info.reassigned + ' reassigned']));
+                var $big = $('<div style="margin-top:10px;font-size:16px;font-weight:800;color:#fff;"></div>').text(info.credits + ' credits');
+                if (info.rank != null) { $('<span style="color:#9aa6b2;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('rank #' + info.rank + ' of ' + info.total).appendTo($big); }
+                if (info.extra) { $('<span style="color:#b794f6;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('(+' + info.extra + ' extra)').appendTo($big); }
+                $('<span style="color:#7a8694;font-weight:500;font-size:11px;margin-left:12px;"></span>').text(info.actioned + ' total actioned').appendTo($big);
+                $c.append($big);
             }
             return $c;
         }
 
         function table(res, d) {
-            var h = res.header;
+            // Short column labels (the grouping row above clarifies defects vs bug reports; keeps columns narrow).
+            var short = res.header.map(function (c) { return c.replace(/^Defects |^Reports |^Total /, '').replace(/ Credits$| Earned$/, ''); });
             var $wrap = $('<div style="overflow-x:auto;"></div>');
             var $tbl = $('<table style="border-collapse:collapse;font-size:12px;width:100%;"></table>');
+            var $thead = $('<thead></thead>');
+            // grouping row: which columns are DEFECTS (Created/Resolved) vs BUG REPORTS (Attached/Trashed/Reassigned)
+            var thg = 'padding:4px 8px;border-bottom:1px solid #2c333a;color:#7a8694;font-size:11px;text-transform:uppercase;letter-spacing:.04em;text-align:center;';
+            var $g = $('<tr></tr>');
+            $('<th colspan="2"></th>').appendTo($g);                                        // # + Name
+            $('<th colspan="2"></th>').attr('style', thg).text('Defects').appendTo($g);      // Created + Resolved
+            $('<th colspan="3"></th>').attr('style', thg).text('Bug reports').appendTo($g);  // Attached + Trashed + Reassigned
+            $('<th colspan="3"></th>').appendTo($g);                                        // Actioned + Extra + Credits
+            $thead.append($g);
+            // label row
             var $hr = $('<tr></tr>');
             $('<th style="text-align:left;padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;">#</th>').appendTo($hr);
-            h.forEach(function (c, i) {
-                // Short column labels so all 9 columns fit without horizontal scroll (the card shows the full names).
-                var lbl = c.replace(/^Defects |^Reports |^Total /, '').replace(/ Credits$| Earned$/, '');
-                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(lbl).appendTo($hr);
+            short.forEach(function (c, i) {
+                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(c).appendTo($hr);
             });
-            $tbl.append($('<thead></thead>').append($hr));
+            $tbl.append($thead.append($hr));
             var $tb = $('<tbody></tbody>');
             d.real.forEach(function (row, idx) {
                 var mine = row[0] === d.myName;
@@ -8367,31 +8506,47 @@ JiTA.credits = {
             return $wrap.append($tbl);
         }
 
+        function fillCard() {
+            return Promise.all([C.getCached(sel), C.getSelf(sel), JiTA.link.currentUser()]).then(function (arr) {
+                var slot = document.getElementById('jita-cred-card-slot');
+                if (slot) { $(slot).empty().append(card(cardInfo(arr[0], arr[1], arr[2]))); }
+                return arr;
+            });
+        }
+
         function render() {
             $scroll.empty();
             $msel.val(sel);
             $scroll.append($('<div class="jita-menu-status">Loading…</div>'));
-            C.getCached(sel).then(function (res) {
+            Promise.all([C.getCached(sel), C.getSelf(sel), JiTA.link.currentUser()]).then(function (arr) {
+                var fullRes = arr[0], selfRes = arr[1], me = arr[2];
                 $scroll.empty();
-                if (!res) {
-                    $scroll.append($('<div class="jita-menu-status"></div>').text('Not computed yet for ' + sel + '. Click Refresh to compute it (can take a minute).'));
+                $scroll.append($('<div id="jita-cred-card-slot"></div>').append(card(cardInfo(fullRes, selfRes, me))));
+                if (!fullRes) {
+                    $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;"></div>')
+                        .text('Leaderboard not computed yet for ' + sel + '. It refreshes automatically, or click Refresh.'));
                     return;
                 }
-                JiTA.link.currentUser().then(function (me) {
-                    var d = C._derive(res, me);
-                    $scroll.append(card(res, d));
-                    if (d.isLead) {
-                        $scroll.append($('<div class="jita-cred-sub">Leaderboard</div>'));
-                        $scroll.append(table(res, d));
-                    } else {
-                        $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;"></div>')
-                            .text('The full leaderboard is visible to leads only.' + (d.myRank ? (' You are ranked #' + d.myRank + ' of ' + d.total + '.') : '')));
-                    }
-                    $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;color:#7a8694;"></div>')
-                        .text('Computed ' + String(res.computedAt || '').replace('T', ' ').slice(0, 16) + ' - ' + d.total + ' members.'));
-                });
+                var d = C._derive(fullRes, me);
+                if (d.isLead) {
+                    $scroll.append($('<div class="jita-cred-sub">Leaderboard</div>'));
+                    $scroll.append(table(fullRes, d));
+                } else {
+                    var info = cardInfo(fullRes, selfRes, me);
+                    $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;"></div>')
+                        .text('The full leaderboard is visible to leads only.' + (info.rank != null ? (' You are ranked #' + info.rank + ' of ' + info.total + '.') : '')));
+                }
+                $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;color:#7a8694;"></div>')
+                    .text('Leaderboard computed ' + String(fullRes.computedAt || '').replace('T', ' ').slice(0, 16) + ' - ' + d.total + ' members. Your own total updates every ~2 min.'));
             });
         }
+
+        // Keep the "You" card fresh while the overlay is open (the self compute writes creditsSelf every ~2 min).
+        var cardTimer = setInterval(function () {
+            if (!document.getElementById('jita-menu')) { clearInterval(cardTimer); return; }
+            fillCard();
+        }, 30 * 1000);
+
         render();
     },
 
@@ -8417,12 +8572,19 @@ JiTA.credits = {
             var el = document.getElementById('jita-credits-badge');
             if (!el) { return; }
             var ym = JiTA.credits._ymNow().ym;
-            JiTA.credits.getCached(ym).then(function (res) {
-                if (!res) { el.textContent = '📊 credits: —'; return; }
-                JiTA.link.currentUser().then(function (me) {
-                    var d = JiTA.credits._derive(res, me);
-                    el.textContent = d.myRow ? ('📊 ' + d.myRow[8] + ' cr · #' + d.myRank + '/' + d.total) : '📊 credits: n/a';
-                });
+            JiTA.credits.getSelf(ym).then(function (self) {
+                if (self && self.credits != null) {
+                    el.textContent = '📊 ' + self.credits + ' cr' + (self.rank != null ? (' · #' + self.rank + '/' + self.total) : '');
+                    return;
+                }
+                // fallback: derive from the full-leaderboard cache until the first self compute lands
+                JiTA.credits.getCached(ym).then(function (res) {
+                    if (!res) { el.textContent = '📊 credits: —'; return; }
+                    JiTA.link.currentUser().then(function (me) {
+                        var d = JiTA.credits._derive(res, me);
+                        el.textContent = d.myRow ? ('📊 ' + d.myRow[8] + ' cr · #' + d.myRank + '/' + d.total) : '📊 credits: n/a';
+                    });
+                }).catch(function () { /* ignore */ });
             }).catch(function () { /* ignore */ });
         },
         remove: function () {
@@ -8431,102 +8593,74 @@ JiTA.credits = {
         }
     },
 
-    // ---- background scheduler (throttled current-month recompute; interval is user-configurable) ----------
+    // ---- background schedulers (two cadences: your own total often, the full leaderboard less often) ------
+    // A single tick() runs on POLL_MS and starts AT MOST ONE job per tick (full takes priority, then self).
+    // Both jobs share the in-memory `running` flag and tick bails if it's set, so within a tab the two can NEVER
+    // overlap. Each job has its own cross-tab lease; different tabs writing different cache keys is harmless.
     sched: {
-        POLL_MS: 60 * 1000,              // check every minute (so even a 5-minute interval is honored closely)
-        STARTUP_DELAY_MS: 25 * 1000,     // let the page settle before the first (possibly heavy) run
-        LEASE_TTL_MS: 90 * 1000,         // lease is heartbeated every 30s while computing; a dead tab's lease expires ~90s after it stops
+        SELF_MS: 2 * 60 * 1000,          // recompute only YOUR credits this often (cheap, self-scoped)
+        FULL_MS: 15 * 60 * 1000,         // recompute the whole leaderboard this often (heavy group crawl)
+        POLL_MS: 30 * 1000,              // how often tick() checks whether either cadence is due
+        STARTUP_DELAY_MS: 20 * 1000,     // let the page settle before the first run
+        FULL_TTL_MS: 90 * 1000,          // full-run lease is heartbeated every 30s; a dead tab's lease expires ~90s after
+        SELF_TTL_MS: 2 * 60 * 1000,      // self run is short, so a plain lease TTL suffices (no heartbeat)
         HEARTBEAT_MS: 30 * 1000,
-        LAST_KEY: 'creditsLastTs',
-        LEASE_KEY: 'creditsLease',
+        LAST_FULL_KEY: 'creditsLastFullTs',
+        LAST_SELF_KEY: 'creditsLastSelfTs',
+        FULL_LEASE_KEY: 'creditsFullLease',
+        SELF_LEASE_KEY: 'creditsSelfLease',
         _timer: null,
 
-        // Auto-update interval in MINUTES, read live from GM storage (0 = manual only). Set from the settings menu.
-        intervalMin: function () { var v = parseInt(gmGet('creditsIntervalMin', 15), 10); return isNaN(v) ? 15 : v; },
-
-        _recently: function () {
-            var iv = JiTA.credits.sched.intervalMin();
-            if (iv <= 0) { return true; }   // manual-only -> never auto-compute
-            var last = gmGet(JiTA.credits.sched.LAST_KEY, 0) || 0;
-            return !!last && (Date.now() - last) < iv * 60 * 1000;
-        },
-        _lease: function () {
-            var l = gmGet(JiTA.credits.sched.LEASE_KEY, null), now = Date.now();
-            if (!l || !l.ts || (now - l.ts) > JiTA.credits.sched.LEASE_TTL_MS || l.tabId === JiTA.sched.tabId) {
-                gmSet(JiTA.credits.sched.LEASE_KEY, { tabId: JiTA.sched.tabId, ts: now });
-                return true;
-            }
+        _elapsed: function (lastKey, ms) { var last = gmGet(lastKey, 0) || 0; return !last || (Date.now() - last) >= ms; },
+        _lease: function (key, ttl) {
+            var l = gmGet(key, null), now = Date.now();
+            if (!l || !l.ts || (now - l.ts) > ttl || l.tabId === JiTA.sched.tabId) { gmSet(key, { tabId: JiTA.sched.tabId, ts: now }); return true; }
             return false;
         },
+        _release: function (key) { var l = gmGet(key, null); if (l && l.tabId === JiTA.sched.tabId) { gmSet(key, null); } },
+
         tick: function () {
             var S = JiTA.credits.sched;
             if (!savedVariables[3][1]) { return; }                 // feature off
-            try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }   // cheap: reflect the latest cache
-            if (JiTA.credits.running) { return; }
-            if (S._recently()) { return; }                         // interval not elapsed (or manual-only)
-            if (!S._lease()) { return; }                           // another tab is computing
+            try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }   // cheap: reflect the latest cache each poll
+            if (JiTA.credits.running) { return; }                  // a job is already running in THIS tab -> never overlap
             var now = JiTA.credits._ymNow();
-            JiTA.credits._quiet = true;                            // background run: no floating pill
-            try { var b = document.getElementById('jita-credits-badge'); if (b) { b.textContent = '📊 updating…'; } } catch (e) { /* ignore */ }
-            // Heartbeat the lease while computing. The compute is in-memory and only writes its result on
-            // completion, so an interrupted run (tab refresh/close) leaves NO partial data and simply restarts
-            // next cycle. The heartbeat means a dead tab's lease goes stale in ~90s (vs. the full TTL), so the
-            // reloaded/other tab picks the work back up promptly instead of skipping cycles.
-            var hb = setInterval(function () { gmSet(S.LEASE_KEY, { tabId: JiTA.sched.tabId, ts: Date.now() }); }, S.HEARTBEAT_MS);
-            var stop = function () { clearInterval(hb); };
-            JiTA.credits.refresh(now.y, now.m).then(function () {
-                gmSet(S.LAST_KEY, Date.now());
-                gmSet(S.LEASE_KEY, null);   // release on success
-                try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }
-                stop();
-            }).catch(function () { stop(); });   // heartbeat stops -> lease expires -> retry next window
+
+            // Full leaderboard (heavy) takes priority. Heartbeats + releases its lease, then refreshes self off the fresh result.
+            if (S._elapsed(S.LAST_FULL_KEY, S.FULL_MS) && S._lease(S.FULL_LEASE_KEY, S.FULL_TTL_MS)) {
+                JiTA.credits._quiet = true;
+                try { var b = document.getElementById('jita-credits-badge'); if (b) { b.textContent = '📊 updating…'; } } catch (e) { /* ignore */ }
+                var hb = setInterval(function () { gmSet(S.FULL_LEASE_KEY, { tabId: JiTA.sched.tabId, ts: Date.now() }); }, S.HEARTBEAT_MS);
+                JiTA.credits.refresh(now.y, now.m).then(function () {
+                    gmSet(S.LAST_FULL_KEY, Date.now());
+                    clearInterval(hb); S._release(S.FULL_LEASE_KEY);
+                    return JiTA.credits.refreshSelf(now.y, now.m).then(function () { gmSet(S.LAST_SELF_KEY, Date.now()); });
+                }).then(function () { try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ } })
+                    .catch(function () { clearInterval(hb); S._release(S.FULL_LEASE_KEY); });
+                return;   // one job per tick
+            }
+
+            // Your own credits (cheap, frequent).
+            if (S._elapsed(S.LAST_SELF_KEY, S.SELF_MS) && S._lease(S.SELF_LEASE_KEY, S.SELF_TTL_MS)) {
+                JiTA.credits.refreshSelf(now.y, now.m).then(function () {
+                    gmSet(S.LAST_SELF_KEY, Date.now()); S._release(S.SELF_LEASE_KEY);
+                }).catch(function () { S._release(S.SELF_LEASE_KEY); });
+            }
         },
+
         start: function () {
             var S = JiTA.credits.sched;
             if (S._timer) { return; }
-            // Release our lease when the tab goes away (refresh / close / navigate) so a reload can recompute at
-            // once instead of waiting out the TTL. Best-effort; the heartbeat + TTL are the backstop if it doesn't fire.
-            try {
-                window.addEventListener('pagehide', function () {
-                    var l = gmGet(S.LEASE_KEY, null);
-                    if (l && l.tabId === JiTA.sched.tabId) { gmSet(S.LEASE_KEY, null); }
-                });
-            } catch (e) { /* ignore */ }
+            // Release our leases when the tab goes away so a reload can pick the work up at once (TTL is the backstop).
+            try { window.addEventListener('pagehide', function () { S._release(S.FULL_LEASE_KEY); S._release(S.SELF_LEASE_KEY); }); } catch (e) { /* ignore */ }
             setTimeout(function () {
                 try { S.tick(); } catch (e) { /* swallow */ }
-                S._timer = setInterval(function () {
-                    try { S.tick(); } catch (e) { /* swallow */ }
-                }, S.POLL_MS);
+                S._timer = setInterval(function () { try { S.tick(); } catch (e) { /* swallow */ } }, S.POLL_MS);
             }, S.STARTUP_DELAY_MS);
         }
     },
 
-    // ---- Phase 1a: manual trigger + console dump (verify against monthly_report.py) ---------------------
-    // Pretty-print the table to the console and return the current user's row + rank.
-    _report: function (res) {
-        var header = res.header, table = res.table;
-        // fixed-width console dump
-        var widths = header.map(function (h, i) {
-            return Math.max.apply(null, [String(h).length].concat(table.map(function (r) { return String(r[i]).length; })));
-        });
-        function line(row) {
-            return row.map(function (c, i) { var s = String(c); return i === 0 ? s + Array(widths[i] - s.length + 1).join(' ') : Array(widths[i] - s.length + 1).join(' ') + s; }).join('  ');
-        }
-        if (window.console) {
-            console.log('[JiTA] ISD credits ' + res.ym + ' (computed ' + res.computedAt + ')');
-            console.log(line(header));
-            table.forEach(function (r) { console.log(line(r)); });
-        }
-        return JiTA.link.currentUser().then(function (me) {
-            var myName = null;
-            for (var name in res.nameToAcc) { if (res.nameToAcc.hasOwnProperty(name) && res.nameToAcc[name] === me) { myName = name; } }
-            // rank among real members (exclude the Total row) by Credits Earned desc
-            var real = table.slice(0, -1).slice().sort(function (a, b) { return b[8] - a[8]; });
-            var myRow = null, myRank = null;
-            for (var i = 0; i < real.length; i++) { if (real[i][0] === myName) { myRow = real[i]; myRank = i + 1; } }
-            return { myName: myName, myRow: myRow, myRank: myRank, total: real.length };
-        });
-    }
+    _noop: null
 };
 
 

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -8470,21 +8470,23 @@ JiTA.credits = {
             var $wrap = $('<div style="overflow-x:auto;"></div>');
             var $tbl = $('<table style="border-collapse:collapse;font-size:12px;width:100%;"></table>');
             var $thead = $('<thead></thead>');
-            // grouping row: DEFECTS sits over its FIRST column (Created), BUG REPORTS over its first (Attached),
-            // each RIGHT-aligned so the caption + its own-width underline line up with the right-bound column header
-            // below it. One cell per column keeps each caption anchored to a specific column, so the two underlines
-            // stay separate instead of merging into one line.
-            var groupLabels = ['', '', 'Defects', '', 'Bug reports', '', '', '', ''];   // #, Name, Created, Resolved, Attached, Trashed, Reassigned, Actioned, Credits
+            // grouping row: the underline spans the FULL group (Created+Resolved / Attached+Trashed+Reassigned),
+            // inset a little so the two groups' underlines don't merge into one line. The caption sits over the
+            // group's FIRST column (Created / Attached), right-aligned to line up with that column's header below.
+            function grpCell(cols, label) {
+                var $th = $('<th colspan="' + cols + '" style="padding:0;"></th>');
+                var $u = $('<div style="margin:0 12px;padding-bottom:4px;border-bottom:1px solid #4a5560;"></div>');
+                $('<div></div>').attr('style', 'width:' + (100 / cols) + '%;box-sizing:border-box;text-align:right;padding-right:8px;' +
+                    'color:#8a94a0;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;white-space:nowrap;')
+                    .text(label).appendTo($u);
+                $u.appendTo($th);
+                return $th;
+            }
             var $g = $('<tr></tr>');
-            groupLabels.forEach(function (label) {
-                var $th = $('<th style="padding:2px 8px 0;text-align:right;"></th>');
-                if (label) {
-                    $('<span></span>').attr('style', 'display:inline-block;padding-bottom:4px;border-bottom:1px solid #4a5560;' +
-                        'color:#8a94a0;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;white-space:nowrap;')
-                        .text(label).appendTo($th);
-                }
-                $th.appendTo($g);
-            });
+            $('<th colspan="2"></th>').appendTo($g);   // # + Name
+            grpCell(2, 'Defects').appendTo($g);        // Created + Resolved
+            grpCell(3, 'Bug reports').appendTo($g);    // Attached + Trashed + Reassigned
+            $('<th colspan="2"></th>').appendTo($g);   // Actioned + Credits
             $thead.append($g);
             // label row
             var $hr = $('<tr></tr>');

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -8493,7 +8493,8 @@ JiTA.credits = {
             $('<th style="text-align:left;padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;">#</th>').appendTo($hr);
             short.forEach(function (c, i) {
                 if (i === 7) { return; }   // Extra Credits column removed (the bonus is still baked into Credits)
-                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(c).appendTo($hr);
+                // numeric columns centred (so they line up under the centred group captions); Name stays left
+                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'center') + ';').text(c).appendTo($hr);
             });
             $tbl.append($thead.append($hr));
             var $tb = $('<tbody></tbody>');
@@ -8508,8 +8509,8 @@ JiTA.credits = {
                 $nt.appendTo($r);
                 for (var i = 1; i < row.length; i++) {
                     if (i === 7) { continue; }   // Extra Credits column removed (still counted in Credits)
-                    var st = 'padding:4px 8px;text-align:right;white-space:nowrap;color:#d7dce2;';
-                    if (i === 8) { st = 'padding:4px 8px;text-align:right;color:#fff;font-weight:800;'; }               // Credits
+                    var st = 'padding:4px 8px;text-align:center;white-space:nowrap;color:#d7dce2;';
+                    if (i === 8) { st = 'padding:4px 8px;text-align:center;color:#fff;font-weight:800;'; }               // Credits
                     $('<td></td>').attr('style', st).text(row[i]).appendTo($r);
                 }
                 $tb.append($r);

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -8471,15 +8471,13 @@ JiTA.credits = {
             var $tbl = $('<table style="border-collapse:collapse;font-size:12px;width:100%;"></table>');
             var $thead = $('<thead></thead>');
             // grouping row: the underline spans the FULL group (Created+Resolved / Attached+Trashed+Reassigned),
-            // inset a little so the two groups' underlines don't merge into one line. The caption sits over the
-            // group's FIRST column (Created / Attached), right-aligned to line up with that column's header below.
+            // inset on the left so the two groups' underlines don't merge. The caption sits over the group's LAST
+            // column (Resolved / Reassigned), right-aligned (padding-right 8px) to line up with that column's header.
             function grpCell(cols, label) {
                 var $th = $('<th colspan="' + cols + '" style="padding:0;"></th>');
-                var $u = $('<div style="margin:0 12px;padding-bottom:4px;border-bottom:1px solid #4a5560;"></div>');
-                $('<div></div>').attr('style', 'width:' + (100 / cols) + '%;box-sizing:border-box;text-align:right;padding-right:8px;' +
+                $('<div></div>').attr('style', 'margin-left:24px;padding:0 8px 4px 0;border-bottom:1px solid #4a5560;text-align:right;' +
                     'color:#8a94a0;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;white-space:nowrap;')
-                    .text(label).appendTo($u);
-                $u.appendTo($th);
+                    .text(label).appendTo($th);
                 return $th;
             }
             var $g = $('<tr></tr>');

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Jira Triage Assistant
-// @version     2.37.0
+// @version     2.39.0
 // @author      ISD BH Schogol, ISD Tulwar
 // @description Adds a Translate, Assign to GM, Convert to Defect and Close button to Jira, parses Log Files submitted from the EVE client, suggests similar existing defects on bug reports, and (on a defect) lists the open bug reports that best match it
 // @updateURL   https://github.com/Schogol/Jira-Triage-Assistant/raw/main/JiTA.user.js
@@ -121,10 +121,11 @@ function gmSet(key, val) {
 
 
 // Array which contains the locally saved values for a couple of variables.
-// NOTE: index 3 ("dropdowns") is a RETIRED feature (Linked Issue Dropdowns, removed because Jira's markup
-// changed and it stopped working). The slot is kept as a placeholder so the later indices (4 = buttons,
-// 5 = similarDefects), which are referenced by number throughout this file, don't shift.
-var savedVariables = [["key",""], ["parser", ""], ["scrollbar", ""], ["dropdowns_retired", ""], ["buttons", ""], ["similarDefects", ""]];
+// NOTE: index 3 was "dropdowns" (Linked Issue Dropdowns), a RETIRED feature (removed when Jira's markup
+// changed). That dead slot is now REPURPOSED as "credits" (the ISD credit tracker) - the key name changed
+// so an existing install's orphaned "dropdowns" value is ignored and credits simply defaults on. Indices
+// 4 = buttons and 5 = similarDefects are referenced by number throughout this file, so they must not shift.
+var savedVariables = [["key",""], ["parser", ""], ["scrollbar", ""], ["credits", ""], ["buttons", ""], ["similarDefects", ""]];
 
 
 // Custom-scrollbar CSS, injected on load (when enabled) and by the scrollbar change-listener below. The
@@ -197,11 +198,10 @@ if (!JITA_IS_FORGE_FRAME) {
     GM_registerMenuCommand("⚙ Jira Triage Assistant - Settings…", function () {
         if (typeof JiTA !== 'undefined' && JiTA.menu) { JiTA.menu.open(); }
     });
-    // Phase 1a (dev): compute the current month's ISD credit table in-browser and dump it to the console so
-    // the numbers can be verified against monthly_report.py. The always-on panel + background refresh + the
-    // leads leaderboard come in later phases.
-    GM_registerMenuCommand("📊 Compute my ISD credits (this month)", function () {
-        if (typeof JiTA !== 'undefined' && JiTA.credits) { JiTA.credits.runManual(); }
+    // Open the ISD Credits overlay (your live monthly total + the leads-only leaderboard). The overlay's
+    // Refresh recomputes the selected month and also dumps the table to the console (verify vs. monthly_report.py).
+    GM_registerMenuCommand("📊 ISD Credits leaderboard…", function () {
+        if (typeof JiTA !== 'undefined' && JiTA.credits) { JiTA.credits.openView(); }
     });
 }
 
@@ -7446,7 +7446,42 @@ JiTA.menu = {
                 JiTA.ui.ensure();
             }
         }));
+        // ISD Credits: mount / tear down the corner badge (and start the scheduler) on toggle.
+        $feat.append(JiTA.menu._toggleRow('ISD Credits', 3, function () {
+            if (!savedVariables[3][1]) { JiTA.credits.badge.remove(); }
+            else { JiTA.credits.badge.mount(); JiTA.credits.sched.start(); }
+        }));
         $p.append($feat);
+
+        // ---- ISD Credits (only when enabled) ----
+        if (savedVariables[3][1]) {
+            JiTA.credits._injectCss();
+            var $cr = $('<div class="jita-menu-sect"></div>');
+            $('<h3>ISD Credits</h3>').appendTo($cr);
+            $('<div class="jita-menu-status">Your live monthly defect-credit total, plus the leads-only leaderboard, computed from Jira.</div>').appendTo($cr);
+            var $crAct = $('<div class="jita-menu-actions"></div>').appendTo($cr);
+            $('<button class="jita-btn">Open leaderboard</button>')
+                .on('click', function () { JiTA.menu.close(); JiTA.credits.openView(); }).appendTo($crAct);
+            $('<button class="jita-btn">Refresh now</button>').on('click', function () {
+                JiTA.menu.close();
+                var now = JiTA.credits._ymNow();
+                JiTA.credits._quiet = false;
+                JiTA.credits.refresh(now.y, now.m).then(function () { JiTA.credits.badge.refresh(); }).catch(function () { /* ignore */ });
+            }).appendTo($crAct);
+            // Auto-update interval: how often the current month is recomputed in the background (0 = manual only).
+            var $ivRow = $('<div class="jita-menu-row"></div>');
+            $('<span class="lbl">Auto-update</span>')
+                .append($('<span class="sub"></span>').text('How often to recompute this month in the background'))
+                .appendTo($ivRow);
+            var $iv = $('<select class="jita-cred-input" style="width:auto;"></select>');
+            [['Manual only', '0'], ['Every hour', '60'], ['Every 3 hours', '180'], ['Every 6 hours', '360'], ['Every 12 hours', '720'], ['Daily', '1440']]
+                .forEach(function (o) { $('<option></option>').val(o[1]).text(o[0]).appendTo($iv); });
+            $iv.val(String(JiTA.credits.sched.intervalMin()));
+            $iv.on('change', function () { gmSet('creditsIntervalMin', parseInt($iv.val(), 10) || 0); });
+            $ivRow.append($iv);
+            $cr.append($ivRow);
+            $p.append($cr);
+        }
 
         // ---- Canned responses (Zendesk Support panel) ----
         // A repository of reusable replies, shown as a dropdown in the Zendesk Support activity panel (picking
@@ -7726,12 +7761,15 @@ JiTA.credits = {
     CRAWL_DELAY_MS: 120,   // polite gap between per-issue changelog GETs (the crawl is the expensive part)
 
     running: false,
+    _quiet: false,        // background (scheduled) runs set this true so the floating pill stays hidden (the badge is the visible artifact)
+    _cssInjected: false,
 
     // ---- progress (page-independent floating pill + console; shows with or without the Similar Defects panel) --
     // A multi-minute crawl needs live feedback. _pill updates a fixed-position status pill (and the panel line
     // when it exists); _log additionally breadcrumbs to the console. Use _pill for every-item ticks (smooth,
     // no console spam) and _log for phase changes / interval milestones.
     _pill: function (msg) {
+        if (JiTA.credits._quiet) { return; }   // scheduled background runs stay silent
         try {
             var el = document.getElementById('jita-credits-progress');
             if (!el) {
@@ -8203,6 +8241,245 @@ JiTA.credits = {
         });
     },
 
+    // ---- shared: per-viewer derivation (your row / rank / lead-ness) ------------------------------------
+    // True if a member's display name carries a lead handle token (e.g. "ISD BH Solnichka" -> "solnichka").
+    _leadFromName: function (name) {
+        var toks = {};
+        (name || '').toLowerCase().replace(/-/g, ' ').split(/\s+/).forEach(function (t) { if (t) { toks[t] = true; } });
+        for (var l in JiTA.credits.LEADS) { if (JiTA.credits.LEADS.hasOwnProperty(l) && toks[l]) { return true; } }
+        return false;
+    },
+    // From a computed/cached result + the viewer's accountId: the members sorted by credits desc, plus which
+    // row is the viewer's, their rank, and whether they're a lead (gates the full leaderboard).
+    _derive: function (res, me) {
+        var real = res.table.slice(0, res.table.length - 1).slice().sort(function (a, b) { return b[8] - a[8]; });
+        var myName = null;
+        for (var name in res.nameToAcc) { if (res.nameToAcc.hasOwnProperty(name) && res.nameToAcc[name] === me) { myName = name; } }
+        var myRow = null, myRank = null;
+        for (var i = 0; i < real.length; i++) { if (real[i][0] === myName) { myRow = real[i]; myRank = i + 1; } }
+        return { real: real, myName: myName, myRow: myRow, myRank: myRank, total: real.length, isLead: JiTA.credits._leadFromName(myName) };
+    },
+
+    // ---- overlay CSS (the wide, scrollable overlay chrome; base menu CSS comes from JiTA.menu._injectCss) --
+    _injectCss: function () {
+        if (JiTA.credits._cssInjected) { return; }
+        JiTA.credits._cssInjected = true;
+        try {
+            GM_addStyle(
+                '#jita-menu.jita-credits-view { width: 760px; max-width: 94vw; display: flex; flex-direction: column; overflow: hidden; }' +
+                '#jita-menu.jita-credits-view .jita-menu-head { flex: 0 0 auto; }' +
+                '#jita-menu.jita-credits-view .jita-cred-scroll { flex: 1 1 auto; min-height: 0; max-height: 68vh; overflow-y: auto; padding: 8px 16px 12px; }' +
+                '#jita-menu.jita-credits-view .jita-cred-foot { flex: 0 0 auto; display: flex; flex-wrap: wrap; gap: 8px; align-items: center; padding: 10px 16px; border-top: 1px solid #3a434d; background: #282d33; }' +
+                '#jita-menu.jita-credits-view .jita-cred-sub { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: #7a8694; margin: 14px 0 6px; }' +
+                '.jita-cred-input { background: #0f1316; color: #e6e6e6; border: 1px solid #3a434d; border-radius: 5px; padding: 4px 8px; font-size: 12px; }'
+            );
+        } catch (e) { /* ignore */ }
+    },
+
+    // ---- the dedicated ISD Credits overlay (your card + leads-only leaderboard, month selector) ----------
+    openView: function (ym) {
+        var C = JiTA.credits, cur = C._ymNow();
+        var sel = ym || cur.ym;
+        C._injectCss();
+        var ov = JiTA.menu._openOverlay({ title: 'ISD Credits', wide: false });
+        ov.$menu.addClass('jita-credits-view');
+        var $scroll = $('<div class="jita-cred-scroll"></div>').appendTo(ov.$menu);
+        var $foot = $('<div class="jita-cred-foot"></div>').appendTo(ov.$menu);
+
+        // footer: month selector (last 12 months) + a Refresh that recomputes the selected month
+        var MON = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+        var $msel = $('<select class="jita-cred-input"></select>');
+        (function () {
+            var y = cur.y, m = cur.m;
+            for (var i = 0; i < 12; i++) {
+                var v = y + '-' + (m < 10 ? '0' : '') + m;
+                $('<option></option>').val(v).text(MON[m - 1] + ' ' + y + (i === 0 ? ' (current)' : '')).appendTo($msel);
+                m--; if (m < 1) { m = 12; y--; }
+            }
+        })();
+        $msel.val(sel).on('change', function () { sel = $msel.val(); render(); });
+        $('<span style="color:#9aa6b2;font-size:12px;">Month</span>').appendTo($foot);
+        $msel.appendTo($foot);
+        var $refresh = $('<button class="jita-btn">Refresh</button>').appendTo($foot);
+        $refresh.on('click', function () {
+            var p = sel.split('-'), yy = parseInt(p[0], 10), mm = parseInt(p[1], 10);
+            $refresh.prop('disabled', true).text('Computing…');
+            C._quiet = false;   // user-triggered: show the progress pill
+            C.refresh(yy, mm).then(function (res) {
+                if (res) { C._report(res); }   // also dump to console (verification)
+                C.badge.refresh();
+                $refresh.prop('disabled', false).text('Refresh');
+                render();
+            }).catch(function (e) {
+                $refresh.prop('disabled', false).text('Refresh');
+                $scroll.prepend($('<div class="jita-menu-status" style="color:#ff8f8f;"></div>').text('Failed: ' + (e && e.message || e)));
+            });
+        });
+
+        function card(res, d) {
+            var h = res.header;
+            var $c = $('<div style="background:#22272b;border:1px solid #2c333a;border-radius:8px;padding:12px 14px;"></div>');
+            $('<div style="font-weight:700;font-size:13px;margin-bottom:8px;"></div>')
+                .text(d.myName ? ('You - ' + d.myName) : 'Your account was not matched to an ECAID member').appendTo($c);
+            if (d.myRow) {
+                var bits = [];
+                for (var i = 1; i <= 6; i++) { bits.push(h[i].replace('Defects ', '').replace('Reports ', '') + ' ' + d.myRow[i]); }
+                $('<div style="color:#c7cdd4;font-size:12px;line-height:1.8;"></div>').text(bits.join('   ')).appendTo($c);
+                var $big = $('<div style="margin-top:8px;font-size:16px;font-weight:800;color:#fff;"></div>').text(d.myRow[8] + ' credits');
+                $('<span style="color:#9aa6b2;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('rank #' + d.myRank + ' of ' + d.total).appendTo($big);
+                if (d.myRow[7]) { $('<span style="color:#b794f6;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('(+' + d.myRow[7] + ' extra)').appendTo($big); }
+                $big.appendTo($c);
+            }
+            return $c;
+        }
+
+        function table(res, d) {
+            var h = res.header;
+            var $wrap = $('<div style="overflow-x:auto;"></div>');
+            var $tbl = $('<table style="border-collapse:collapse;font-size:12px;width:100%;"></table>');
+            var $hr = $('<tr></tr>');
+            $('<th style="text-align:left;padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;">#</th>').appendTo($hr);
+            h.forEach(function (c, i) {
+                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(c).appendTo($hr);
+            });
+            $tbl.append($('<thead></thead>').append($hr));
+            var $tb = $('<tbody></tbody>');
+            d.real.forEach(function (row, idx) {
+                var mine = row[0] === d.myName;
+                var $r = $('<tr></tr>').attr('style', mine ? 'background:#20303f;' : '');
+                $('<td style="padding:4px 8px;color:#7a8694;"></td>').text(idx + 1).appendTo($r);
+                var acc = res.nameToAcc[row[0]];
+                var $nt = $('<td style="padding:4px 8px;white-space:nowrap;font-weight:600;"></td>');
+                if (acc) { $('<a target="_blank" rel="noopener" style="color:#b794f6;text-decoration:none;"></a>').attr('href', JiTA.HOST + '/jira/people/' + acc).text(row[0]).appendTo($nt); }
+                else { $nt.text(row[0]); }
+                $nt.appendTo($r);
+                for (var i = 1; i < row.length; i++) {
+                    var st = 'padding:4px 8px;text-align:right;white-space:nowrap;color:#d7dce2;';
+                    if (i === 7 && row[i]) { st = 'padding:4px 8px;text-align:right;color:#b794f6;font-weight:700;'; }   // Extra
+                    if (i === 8) { st = 'padding:4px 8px;text-align:right;color:#fff;font-weight:800;'; }               // Credits
+                    $('<td></td>').attr('style', st).text(row[i]).appendTo($r);
+                }
+                $tb.append($r);
+            });
+            $tbl.append($tb);
+            return $wrap.append($tbl);
+        }
+
+        function render() {
+            $scroll.empty();
+            $msel.val(sel);
+            $scroll.append($('<div class="jita-menu-status">Loading…</div>'));
+            C.getCached(sel).then(function (res) {
+                $scroll.empty();
+                if (!res) {
+                    $scroll.append($('<div class="jita-menu-status"></div>').text('Not computed yet for ' + sel + '. Click Refresh to compute it (can take a minute).'));
+                    return;
+                }
+                JiTA.link.currentUser().then(function (me) {
+                    var d = C._derive(res, me);
+                    $scroll.append(card(res, d));
+                    if (d.isLead) {
+                        $scroll.append($('<div class="jita-cred-sub">Leaderboard</div>'));
+                        $scroll.append(table(res, d));
+                    } else {
+                        $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;"></div>')
+                            .text('The full leaderboard is visible to leads only.' + (d.myRank ? (' You are ranked #' + d.myRank + ' of ' + d.total + '.') : '')));
+                    }
+                    $scroll.append($('<div class="jita-menu-status" style="margin-top:12px;color:#7a8694;"></div>')
+                        .text('Computed ' + String(res.computedAt || '').replace('T', ' ').slice(0, 16) + ' - ' + d.total + ' members.'));
+                });
+            });
+        }
+        render();
+    },
+
+    // ---- always-on corner badge (your current-month total + rank; reads cache; click opens the view) -----
+    badge: {
+        mount: function () {
+            if (!savedVariables[3][1] || JITA_IS_FORGE_FRAME) { return; }
+            var el = document.getElementById('jita-credits-badge');
+            if (!el) {
+                el = document.createElement('div');
+                el.id = 'jita-credits-badge';
+                el.style.cssText = 'position:fixed;z-index:9000;left:16px;bottom:16px;cursor:pointer;' +
+                    'background:#1a1c1f;color:#e8e8ea;border:1px solid #34373d;border-radius:16px;padding:6px 12px;' +
+                    'font:12px/1 "Segoe UI",Roboto,Arial,sans-serif;box-shadow:0 3px 12px rgba(0,0,0,.4);user-select:none;';
+                el.title = 'ISD credits this month - click for the leaderboard';
+                el.addEventListener('click', function () { JiTA.credits.openView(); });
+                (document.body || document.documentElement).appendChild(el);
+                el.textContent = '📊 credits…';
+            }
+            JiTA.credits.badge.refresh();
+        },
+        refresh: function () {
+            var el = document.getElementById('jita-credits-badge');
+            if (!el) { return; }
+            var ym = JiTA.credits._ymNow().ym;
+            JiTA.credits.getCached(ym).then(function (res) {
+                if (!res) { el.textContent = '📊 credits: —'; return; }
+                JiTA.link.currentUser().then(function (me) {
+                    var d = JiTA.credits._derive(res, me);
+                    el.textContent = d.myRow ? ('📊 ' + d.myRow[8] + ' cr · #' + d.myRank + '/' + d.total) : '📊 credits: n/a';
+                });
+            }).catch(function () { /* ignore */ });
+        },
+        remove: function () {
+            var el = document.getElementById('jita-credits-badge');
+            if (el && el.parentNode) { el.parentNode.removeChild(el); }
+        }
+    },
+
+    // ---- background scheduler (throttled current-month recompute; interval is user-configurable) ----------
+    sched: {
+        POLL_MS: 5 * 60 * 1000,          // how often we CHECK whether the interval has elapsed
+        STARTUP_DELAY_MS: 25 * 1000,     // let the page settle before the first (possibly heavy) run
+        LEASE_TTL_MS: 20 * 60 * 1000,    // a full compute can take minutes; treat an older lease as abandoned
+        LAST_KEY: 'creditsLastTs',
+        LEASE_KEY: 'creditsLease',
+        _timer: null,
+
+        // Auto-update interval in MINUTES, read live from GM storage (0 = manual only). Set from the settings menu.
+        intervalMin: function () { var v = parseInt(gmGet('creditsIntervalMin', 180), 10); return isNaN(v) ? 180 : v; },
+
+        _recently: function () {
+            var iv = JiTA.credits.sched.intervalMin();
+            if (iv <= 0) { return true; }   // manual-only -> never auto-compute
+            var last = gmGet(JiTA.credits.sched.LAST_KEY, 0) || 0;
+            return !!last && (Date.now() - last) < iv * 60 * 1000;
+        },
+        _lease: function () {
+            var l = gmGet(JiTA.credits.sched.LEASE_KEY, null), now = Date.now();
+            if (!l || !l.ts || (now - l.ts) > JiTA.credits.sched.LEASE_TTL_MS || l.tabId === JiTA.sched.tabId) {
+                gmSet(JiTA.credits.sched.LEASE_KEY, { tabId: JiTA.sched.tabId, ts: now });
+                return true;
+            }
+            return false;
+        },
+        tick: function () {
+            if (!savedVariables[3][1]) { return; }                 // feature off
+            try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }   // cheap: reflect the latest cache
+            if (JiTA.credits.running) { return; }
+            if (JiTA.credits.sched._recently()) { return; }        // interval not elapsed (or manual-only)
+            if (!JiTA.credits.sched._lease()) { return; }          // another tab is computing
+            var now = JiTA.credits._ymNow();
+            JiTA.credits._quiet = true;                            // background run: no floating pill
+            try { var b = document.getElementById('jita-credits-badge'); if (b) { b.textContent = '📊 updating…'; } } catch (e) { /* ignore */ }
+            JiTA.credits.refresh(now.y, now.m).then(function () {
+                gmSet(JiTA.credits.sched.LAST_KEY, Date.now());
+                try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }
+            }).catch(function () { /* swallow; retry next window */ });
+        },
+        start: function () {
+            if (JiTA.credits.sched._timer) { return; }
+            setTimeout(function () {
+                try { JiTA.credits.sched.tick(); } catch (e) { /* swallow */ }
+                JiTA.credits.sched._timer = setInterval(function () {
+                    try { JiTA.credits.sched.tick(); } catch (e) { /* swallow */ }
+                }, JiTA.credits.sched.POLL_MS);
+            }, JiTA.credits.sched.STARTUP_DELAY_MS);
+        }
+    },
+
     // ---- Phase 1a: manual trigger + console dump (verify against monthly_report.py) ---------------------
     // Pretty-print the table to the console and return the current user's row + rank.
     _report: function (res) {
@@ -8227,23 +8504,6 @@ JiTA.credits = {
             var myRow = null, myRank = null;
             for (var i = 0; i < real.length; i++) { if (real[i][0] === myName) { myRow = real[i]; myRank = i + 1; } }
             return { myName: myName, myRow: myRow, myRank: myRank, total: real.length };
-        });
-    },
-
-    runManual: function () {
-        var now = JiTA.credits._ymNow();
-        JiTA.ui.toast('Computing ISD credits for ' + now.ym + '… (see console; this can take a while)');
-        JiTA.credits.refresh(now.y, now.m).then(function (res) {
-            if (!res) { return; }
-            return JiTA.credits._report(res).then(function (mine) {
-                if (mine.myRow) {
-                    JiTA.ui.toast('Your credits ' + now.ym + ': ' + mine.myRow[8] + ' (rank ' + mine.myRank + '/' + mine.total + '). Full table in console.');
-                } else {
-                    JiTA.ui.toast('Credits ' + now.ym + ' computed (' + mine.total + ' members). Full table in console. (Your account was not matched to a member.)');
-                }
-            });
-        }).catch(function (e) {
-            alert('Credit computation failed: ' + (e && e.message || e) + '\nReport issues to Schogol :).');
         });
     }
 };
@@ -8282,6 +8542,11 @@ JiTA.credits = {
     }
     // start the periodic background catch-up sync
     JiTA.sched.start();
+    // ISD credit tracker: show the corner badge (from cache) and start the throttled background recompute.
+    if (savedVariables[3][1]) {
+        try { JiTA.credits.badge.mount(); } catch (e) { /* swallow */ }
+        try { JiTA.credits.sched.start(); } catch (e) { /* swallow */ }
+    }
 })();
 
 

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -7939,10 +7939,12 @@ JiTA.credits = {
         return { start: y + '-' + p2(m) + '-01', end: ny + '-' + p2(nm) + '-01' };
     },
 
-    _creditFormula: function (r, extra) {
+    // NOTE: diverges from monthly_report.py - the Extra Credits (lead/mentor bonus) is intentionally NOT
+    // added to the score here. It's still computed + stored (index 7) but no longer affects Credits or rank.
+    _creditFormula: function (r) {
         var filtered = r.attached + r.trashed;
         var c = 0.3 * Math.min(100, filtered) + 0.1 * Math.max(0, filtered - 100);
-        c += 0.1 * r.reassigned + r.created + r.resolved + (extra || 0);
+        c += 0.1 * r.reassigned + r.created + r.resolved;
         return Math.round(c * 10) / 10;
     },
 
@@ -8186,7 +8188,7 @@ JiTA.credits = {
                         names.forEach(function (n) {
                             var r = rows[n], extra = extras[n] || 0;
                             var actioned = r.attached + r.trashed + r.reassigned + r.created;
-                            var earned = C._creditFormula(r, extra);
+                            var earned = C._creditFormula(r);
                             table.push([n, r.created, r.resolved, r.attached, r.trashed, r.reassigned, actioned, extra, earned]);
                             tot.created += r.created; tot.resolved += r.resolved; tot.attached += r.attached;
                             tot.trashed += r.trashed; tot.reassigned += r.reassigned; tot.actioned += actioned;
@@ -8316,7 +8318,7 @@ JiTA.credits = {
                         .then(function (rep) {
                             var r = rows[id.myName];
                             r.attached = rep.attached; r.trashed = rep.trashed; r.reassigned = id.reassigned;
-                            var credits = C._creditFormula(r, id.extra);
+                            var credits = C._creditFormula(r);
                             var actioned = r.attached + r.trashed + r.reassigned + r.created;
                             var rank = null, total = null;
                             if (id.fullTable) {
@@ -8456,7 +8458,6 @@ JiTA.credits = {
                 $c.append(group('Bug reports', [info.attached + ' attached', info.trashed + ' trashed', info.reassigned + ' reassigned']));
                 var $big = $('<div style="margin-top:10px;font-size:16px;font-weight:800;color:#fff;"></div>').text(info.credits + ' credits');
                 if (info.rank != null) { $('<span style="color:#9aa6b2;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('rank #' + info.rank + ' of ' + info.total).appendTo($big); }
-                if (info.extra) { $('<span style="color:#b794f6;font-weight:600;font-size:12px;margin-left:12px;"></span>').text('(+' + info.extra + ' extra)').appendTo($big); }
                 $('<span style="color:#7a8694;font-weight:500;font-size:11px;margin-left:12px;"></span>').text(info.actioned + ' total actioned').appendTo($big);
                 $c.append($big);
             }

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -8470,31 +8470,29 @@ JiTA.credits = {
             var $wrap = $('<div style="overflow-x:auto;"></div>');
             var $tbl = $('<table style="border-collapse:collapse;font-size:12px;width:100%;"></table>');
             var $thead = $('<thead></thead>');
-            // grouping row: DEFECTS (Created/Resolved) vs BUG REPORTS (Attached/Trashed/Reassigned). The caption +
-            // its underline live in an INSET div, so each group's underline is separated by a gap (adjacent <th>
-            // bottom-borders would otherwise merge into one long line) and the label is centred over its columns.
+            // grouping row: DEFECTS sits over its FIRST column (Created), BUG REPORTS over its first (Attached),
+            // each RIGHT-aligned so the caption + its own-width underline line up with the right-bound column header
+            // below it. One cell per column keeps each caption anchored to a specific column, so the two underlines
+            // stay separate instead of merging into one line.
+            var groupLabels = ['', '', 'Defects', '', 'Bug reports', '', '', '', ''];   // #, Name, Created, Resolved, Attached, Trashed, Reassigned, Actioned, Credits
             var $g = $('<tr></tr>');
-            function grpCell(colspan, label) {
-                var $th = $('<th colspan="' + colspan + '"></th>');
+            groupLabels.forEach(function (label) {
+                var $th = $('<th style="padding:2px 8px 0;text-align:right;"></th>');
                 if (label) {
-                    $('<div></div>').attr('style', 'margin:0 16px;padding-bottom:4px;border-bottom:1px solid #4a5560;' +
-                        'text-align:center;color:#8a94a0;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;')
+                    $('<span></span>').attr('style', 'display:inline-block;padding-bottom:4px;border-bottom:1px solid #4a5560;' +
+                        'color:#8a94a0;font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.07em;white-space:nowrap;')
                         .text(label).appendTo($th);
                 }
-                return $th;
-            }
-            $g.append(grpCell(2, ''));             // # + Name
-            $g.append(grpCell(2, 'Defects'));      // Created + Resolved
-            $g.append(grpCell(3, 'Bug reports'));  // Attached + Trashed + Reassigned
-            $g.append(grpCell(2, ''));             // Actioned + Credits
+                $th.appendTo($g);
+            });
             $thead.append($g);
             // label row
             var $hr = $('<tr></tr>');
             $('<th style="text-align:left;padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;">#</th>').appendTo($hr);
             short.forEach(function (c, i) {
                 if (i === 7) { return; }   // Extra Credits column removed (the bonus is still baked into Credits)
-                // numeric columns centred (so they line up under the centred group captions); Name stays left
-                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'center') + ';').text(c).appendTo($hr);
+                // numeric columns right-aligned; Name stays left
+                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(c).appendTo($hr);
             });
             $tbl.append($thead.append($hr));
             var $tb = $('<tbody></tbody>');
@@ -8509,8 +8507,8 @@ JiTA.credits = {
                 $nt.appendTo($r);
                 for (var i = 1; i < row.length; i++) {
                     if (i === 7) { continue; }   // Extra Credits column removed (still counted in Credits)
-                    var st = 'padding:4px 8px;text-align:center;white-space:nowrap;color:#d7dce2;';
-                    if (i === 8) { st = 'padding:4px 8px;text-align:center;color:#fff;font-weight:800;'; }               // Credits
+                    var st = 'padding:4px 8px;text-align:right;white-space:nowrap;color:#d7dce2;';
+                    if (i === 8) { st = 'padding:4px 8px;text-align:right;color:#fff;font-weight:800;'; }               // Credits
                     $('<td></td>').attr('style', st).text(row[i]).appendTo($r);
                 }
                 $tb.append($r);

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -8475,12 +8475,13 @@ JiTA.credits = {
             $('<th colspan="2"></th>').appendTo($g);                                        // # + Name
             $('<th colspan="2"></th>').attr('style', thg).text('Defects').appendTo($g);      // Created + Resolved
             $('<th colspan="3"></th>').attr('style', thg).text('Bug reports').appendTo($g);  // Attached + Trashed + Reassigned
-            $('<th colspan="3"></th>').appendTo($g);                                        // Actioned + Extra + Credits
+            $('<th colspan="2"></th>').appendTo($g);                                        // Actioned + Credits
             $thead.append($g);
             // label row
             var $hr = $('<tr></tr>');
             $('<th style="text-align:left;padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;">#</th>').appendTo($hr);
             short.forEach(function (c, i) {
+                if (i === 7) { return; }   // Extra Credits column removed (the bonus is still baked into Credits)
                 $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(c).appendTo($hr);
             });
             $tbl.append($thead.append($hr));
@@ -8495,8 +8496,8 @@ JiTA.credits = {
                 else { $nt.text(row[0]); }
                 $nt.appendTo($r);
                 for (var i = 1; i < row.length; i++) {
+                    if (i === 7) { continue; }   // Extra Credits column removed (still counted in Credits)
                     var st = 'padding:4px 8px;text-align:right;white-space:nowrap;color:#d7dce2;';
-                    if (i === 7 && row[i]) { st = 'padding:4px 8px;text-align:right;color:#b794f6;font-weight:700;'; }   // Extra
                     if (i === 8) { st = 'padding:4px 8px;text-align:right;color:#fff;font-weight:800;'; }               // Credits
                     $('<td></td>').attr('style', st).text(row[i]).appendTo($r);
                 }

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -197,6 +197,12 @@ if (!JITA_IS_FORGE_FRAME) {
     GM_registerMenuCommand("⚙ Jira Triage Assistant - Settings…", function () {
         if (typeof JiTA !== 'undefined' && JiTA.menu) { JiTA.menu.open(); }
     });
+    // Phase 1a (dev): compute the current month's ISD credit table in-browser and dump it to the console so
+    // the numbers can be verified against monthly_report.py. The always-on panel + background refresh + the
+    // leads leaderboard come in later phases.
+    GM_registerMenuCommand("📊 Compute my ISD credits (this month)", function () {
+        if (typeof JiTA !== 'undefined' && JiTA.credits) { JiTA.credits.runManual(); }
+    });
 }
 
 
@@ -7677,6 +7683,568 @@ JiTA.sched = {
                 try { JiTA.sched.tick(); } catch (e) { /* swallow */ }
             }, JiTA.sched.POLL_MS);
         }, JiTA.sched.STARTUP_DELAY_MS);
+    }
+};
+
+
+/* ---- ISD monthly credit tracker: live current-month credit calc (+ leaderboard, later phases) ----
+ * Ports scratchpad/monthly_report.py to run IN-BROWSER against the logged-in ISD's Jira SESSION (read-only,
+ * no API token). Same credit formula and attribution rules, so the live number matches the authoritative
+ * month-end Python run. The computed per-member table is cached in the meta store (key credits:<YYYY-MM>);
+ * past months are computed once (they don't change) and the current month is refreshed on demand / by a
+ * throttled background job (added in a later phase).
+ *
+ * PARITY: keep this in lockstep with monthly_report.py. Mirrored here: the credit formula, projects
+ * (EO/PLAT/EDR) + resolutions (Fixed/Done/Released), clone dedup via the "Cloners" link (union-find),
+ * reopen-aware Attached/Trashed attribution, automation-account re-credit (a BR converted to a defect sets
+ * -> Attached as the automation app account; credit the assignee who triggered it), Team -> GM reassignment
+ * changelog crawl (date-gated), old-account (<handle>@ccpgames.com) bridging, and the hardcoded leads bonus.
+ * Change one, change both.
+ */
+JiTA.credits = {
+    // ---- config (mirror monthly_report.py) ----
+    PROJECTS: 'EO, PLAT, EDR',
+    RESOLUTIONS: 'Fixed, Done, Released',
+    GROUP: 'Contractors ISD ECAID',
+    OLD_DOMAIN: 'ccpgames.com',
+    EBR: 'EBR',
+    ATTACHED_STATUS: 'Attached',
+    CLOSED_STATUS: 'Closed',
+    TEAM_JQL: 'Team[Team]',
+    TEAM_CF: 'customfield_10001',
+    GM_TEAM_ID: '38',                                              // short id (button / JQL)
+    GM_TEAM_FULL_ID: 'ef4edd53-c099-4431-82af-9b4bd717cb88-38',   // full id (changelog `to`)
+    GM_TEAM_NAME: 'EO - GameMasters',                             // changelog `toString`
+    AUTOMATION_ID: '557058:f58131cb-b67d-43c7-b30d-6b58d40bd077', // "Automation for Jira" app account
+    AUTOMATION_EMAIL: 'workato@ccpgames.com',
+    DEDUP_LINK_TYPES: { 'Cloners': true },
+    PROJECT_RANK: { EO: 0, PLAT: 1, EDR: 2 },
+    LEADS: { schogol: true, solnichka: true, lookuptable: true }, // handle token in display name -> lead bonus
+    LEAD_BONUS: 20,
+
+    PAGE_SIZE: 100,
+    CRAWL_DELAY_MS: 120,   // polite gap between per-issue changelog GETs (the crawl is the expensive part)
+
+    running: false,
+
+    // ---- progress (page-independent floating pill + console; shows with or without the Similar Defects panel) --
+    // A multi-minute crawl needs live feedback. _pill updates a fixed-position status pill (and the panel line
+    // when it exists); _log additionally breadcrumbs to the console. Use _pill for every-item ticks (smooth,
+    // no console spam) and _log for phase changes / interval milestones.
+    _pill: function (msg) {
+        try {
+            var el = document.getElementById('jita-credits-progress');
+            if (!el) {
+                el = document.createElement('div');
+                el.id = 'jita-credits-progress';
+                el.style.cssText = 'position:fixed;z-index:2147483647;right:16px;bottom:16px;max-width:360px;' +
+                    'background:#1a1c1f;color:#e8e8ea;border:1px solid #34373d;border-radius:8px;padding:9px 13px;' +
+                    'font:12px/1.45 "Segoe UI",Roboto,Arial,sans-serif;box-shadow:0 4px 16px rgba(0,0,0,.45);' +
+                    'white-space:pre-line;pointer-events:none;';
+                (document.body || document.documentElement).appendChild(el);
+            }
+            el.textContent = '📊 ISD credits\n' + msg;
+        } catch (e) { /* ignore */ }
+        try { JiTA.ui.setStatus('Credits: ' + msg); } catch (e2) { /* ignore */ }   // also feed the panel line when present
+    },
+    _log: function (msg) { JiTA.credits._pill(msg); if (window.console) { console.log('[JiTA] credits: ' + msg); } },
+    _clearProgress: function () {
+        try { var el = document.getElementById('jita-credits-progress'); if (el && el.parentNode) { el.parentNode.removeChild(el); } } catch (e) { /* ignore */ }
+    },
+
+    // ---- REST (session-authenticated, read-only) --------------------------------------------------------
+    // GET with the session cookie; retries on 429 (honoring Retry-After) and transient 5xx.
+    _get: function (path) {
+        return new Promise(function (resolve, reject) {
+            (function attempt(retries) {
+                $.ajax({ url: JiTA.HOST + path, type: 'GET', dataType: 'json' })
+                    .done(function (data) { resolve(data); })
+                    .fail(function (xhr) {
+                        if ((xhr.status === 429 || xhr.status >= 500) && retries > 0) {
+                            var ra = parseInt(xhr.getResponseHeader('Retry-After'), 10);
+                            setTimeout(function () { attempt(retries - 1); }, (isNaN(ra) ? 3 : ra) * 1000);
+                        } else {
+                            reject(new Error('GET ' + path + ' -> HTTP ' + xhr.status));
+                        }
+                    });
+            })(JiTA.MAX_RETRIES);
+        });
+    },
+
+    // One page of /search/jql (reuses the sync engine's POST helper: session auth + 429 retry).
+    _searchPage: function (jql, fields, token) {
+        var body = { jql: jql, fields: fields, maxResults: JiTA.credits.PAGE_SIZE };
+        if (token) { body.nextPageToken = token; }
+        return JiTA.sync._apiPost('/rest/api/3/search/jql', body).then(function (r) { return r.data || {}; });
+    },
+
+    // All matching issues (full field objects), paginated.
+    _fetchIssues: function (jql, fields) {
+        var out = [];
+        function page(token) {
+            return JiTA.credits._searchPage(jql, fields, token).then(function (d) {
+                out = out.concat(d.issues || []);
+                var next = d.nextPageToken || null;
+                if (!next || d.isLast) { return out; }
+                return JiTA.util.delay(JiTA.PAGE_DELAY_MS).then(function () { return page(next); });
+            });
+        }
+        return page(null);
+    },
+
+    // Just the keys matching jql, as a { key: true } set.
+    _allKeys: function (jql) {
+        return JiTA.credits._fetchIssues(jql, ['key']).then(function (issues) {
+            var keys = {};
+            for (var i = 0; i < issues.length; i++) { keys[issues[i].key] = true; }
+            return keys;
+        });
+    },
+
+    // Full changelog for an issue (dedicated paginated endpoint, so no 100-entry truncation), oldest-first.
+    _allHistories: function (key) {
+        var out = [];
+        function page(start) {
+            return JiTA.credits._get('/rest/api/3/issue/' + key + '/changelog?startAt=' + start + '&maxResults=100').then(function (res) {
+                var vals = res.values || [];
+                out = out.concat(vals);
+                if (start + vals.length >= (res.total || 0) || !vals.length) {
+                    out.sort(function (a, b) { return (a.created || '') < (b.created || '') ? -1 : 1; });
+                    return out;
+                }
+                return page(start + vals.length);
+            });
+        }
+        return page(0);
+    },
+
+    // Run fn(item, i) over items ONE AT A TIME (polite to rate limits), resolving to the array of results.
+    _serial: function (items, fn) {
+        var out = [];
+        return items.reduce(function (p, item, i) {
+            return p.then(function () { return fn(item, i); }).then(function (r) { out.push(r); });
+        }, Promise.resolve()).then(function () { return out; });
+    },
+
+    _accList: function (accounts) {
+        return accounts.map(function (a) { return '"' + a + '"'; }).join(', ');
+    },
+
+    // ---- member resolution (group members + pre-migration <handle>@ccpgames.com accounts) ----------------
+    _groupMembers: function (group) {
+        group = group || JiTA.credits.GROUP;
+        var out = [];
+        function page(param, start) {
+            return JiTA.credits._get('/rest/api/3/group/member?' + param +
+                '&includeInactiveUsers=true&startAt=' + start + '&maxResults=50').then(function (res) {
+                var vals = res.values || [];
+                out = out.concat(vals);
+                if (res.isLast || !vals.length) { return out; }
+                return page(param, start + vals.length);
+            });
+        }
+        // Prefer groupname; fall back to groupId (some instances reject groupname on /group/member).
+        return page('groupname=' + encodeURIComponent(group), 0).catch(function () {
+            return JiTA.credits._get('/rest/api/3/groups/picker?query=' + encodeURIComponent(group)).then(function (res) {
+                var gid = null, gs = (res && res.groups) || [];
+                for (var i = 0; i < gs.length; i++) { if ((gs[i].name || '').toLowerCase() === group.toLowerCase()) { gid = gs[i].groupId; } }
+                if (!gid) { throw new Error('group not found: ' + group); }
+                out = [];
+                return page('groupId=' + encodeURIComponent(gid), 0);
+            });
+        });
+    },
+
+    // Candidate login handles for a member, most reliable first (email local-part, then display name variants).
+    _handles: function (member) {
+        var out = [], seen = {};
+        var email = member.emailAddress || '';
+        if (email.indexOf('@') > 0) { out.push(email.split('@')[0]); }
+        var dn = (member.displayName || '').replace(/^\s+|\s+$/g, '');
+        var norm = /^isd /i.test(dn) ? dn.slice(4) : dn;
+        out.push(norm.replace(/ /g, '').toLowerCase());
+        out.push(norm.split(' ')[0].toLowerCase());
+        var uniq = [];
+        for (var i = 0; i < out.length; i++) { var h = out[i]; if (h && !seen[h]) { seen[h] = true; uniq.push(h); } }
+        return uniq;
+    },
+
+    // accountId that `value` resolves to (read off one of its issues); '' if it resolves but has no issues,
+    // null if it doesn't resolve to a user at all.
+    _reporterAccount: function (value) {
+        return JiTA.credits._searchPage('reporter = "' + value + '"', ['reporter'], null).then(function (d) {
+            var issues = d.issues || [];
+            if (!issues.length) { return ''; }
+            return ((issues[0].fields || {}).reporter || {}).accountId || '';
+        }, function () { return null; });
+    },
+
+    // For each member, find & verify their <handle>@OLD_DOMAIN account. Returns { oldIds: {id:true},
+    // oldNames: {oldAccountId: currentMemberName} }.
+    _resolveOldReporters: function (members) {
+        var claimed = {}, oldIds = {}, oldNames = {};
+        return JiTA.credits._serial(members, function (m, i) {
+            JiTA.credits._pill('resolving members: ' + (i + 1) + '/' + members.length);
+            var dn = m.displayName || m.accountId;
+            var cands = JiTA.credits._handles(m).map(function (h) { return h + '@' + JiTA.credits.OLD_DOMAIN; });
+            return JiTA.credits._serial(cands, function (cand) {
+                if (claimed[cand]) { return null; }
+                return JiTA.credits._reporterAccount(cand).then(function (aid) {
+                    return aid === null ? null : { cand: cand, aid: aid };
+                });
+            }).then(function (results) {
+                for (var i = 0; i < results.length; i++) {
+                    var hit = results[i];
+                    if (hit) {
+                        claimed[hit.cand] = true;
+                        if (hit.aid) { oldIds[hit.aid] = true; oldNames[hit.aid] = dn; }
+                        break;   // first resolving handle wins for this member
+                    }
+                }
+            });
+        }).then(function () { return { oldIds: oldIds, oldNames: oldNames }; });
+    },
+
+    // ---- month + formula --------------------------------------------------------------------------------
+    _monthBounds: function (y, m) {
+        var ny = m === 12 ? y + 1 : y, nm = m === 12 ? 1 : m + 1;
+        var p2 = function (n) { return (n < 10 ? '0' : '') + n; };
+        return { start: y + '-' + p2(m) + '-01', end: ny + '-' + p2(nm) + '-01' };
+    },
+
+    _creditFormula: function (r, extra) {
+        var filtered = r.attached + r.trashed;
+        var c = 0.3 * Math.min(100, filtered) + 0.1 * Math.max(0, filtered - 100);
+        c += 0.1 * r.reassigned + r.created + r.resolved + (extra || 0);
+        return Math.round(c * 10) / 10;
+    },
+
+    // ---- defects (created + resolved, clone-deduped) ----------------------------------------------------
+    _defectsCreated: function (accounts, b, acctToName, rows) {
+        var jql = 'project in (' + JiTA.credits.PROJECTS + ') AND issuetype = Defect ' +
+            'AND reporter in (' + JiTA.credits._accList(accounts) + ') ' +
+            'AND created >= "' + b.start + '" AND created < "' + b.end + '" ' +
+            'AND (resolution is EMPTY OR resolution != Duplicate)';
+        return JiTA.credits._fetchIssues(jql, ['reporter', 'project']).then(function (issues) {
+            for (var i = 0; i < issues.length; i++) {
+                var name = acctToName[((issues[i].fields || {}).reporter || {}).accountId];
+                if (name) { rows[name].created++; }
+            }
+        });
+    },
+
+    _defectsResolved: function (accounts, b, acctToName, rows) {
+        var jql = 'project in (' + JiTA.credits.PROJECTS + ') AND issuetype = Defect ' +
+            'AND reporter in (' + JiTA.credits._accList(accounts) + ') ' +
+            'AND resolution in (' + JiTA.credits.RESOLUTIONS + ') ' +
+            'AND resolved >= "' + b.start + '" AND resolved < "' + b.end + '"';
+        return JiTA.credits._fetchIssues(jql, ['reporter', 'project', 'issuelinks']).then(function (issues) {
+            var present = {}, meta = {};
+            for (var i = 0; i < issues.length; i++) { present[issues[i].key] = true; meta[issues[i].key] = issues[i]; }
+            // union-find over Cloners links so a cloned pair counts as ONE real defect (chains too).
+            var parent = {};
+            function find(x) { if (parent[x] === undefined) { parent[x] = x; } while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; }
+            function union(a, c) { var ra = find(a), rb = find(c); if (ra !== rb) { parent[ra] = rb; } }
+            for (var k in present) { if (present.hasOwnProperty(k)) { find(k); } }
+            for (var j = 0; j < issues.length; j++) {
+                var links = (issues[j].fields || {}).issuelinks || [];
+                for (var l = 0; l < links.length; l++) {
+                    if (!JiTA.credits.DEDUP_LINK_TYPES[(links[l].type || {}).name]) { continue; }
+                    var other = links[l].inwardIssue || links[l].outwardIssue;
+                    if (other && present[other.key]) { union(issues[j].key, other.key); }
+                }
+            }
+            function rank(key) {
+                var pk = (meta[key].fields.project || {}).key;
+                var pr = JiTA.credits.PROJECT_RANK[pk]; return (pr === undefined ? 99 : pr);
+            }
+            var comps = {};
+            for (var kk in present) { if (present.hasOwnProperty(kk)) { var root = find(kk); (comps[root] = comps[root] || []).push(kk); } }
+            for (var root2 in comps) {
+                if (!comps.hasOwnProperty(root2)) { continue; }
+                var keep = comps[root2][0];
+                for (var q = 1; q < comps[root2].length; q++) {
+                    var cand = comps[root2][q];
+                    if (rank(cand) < rank(keep) || (rank(cand) === rank(keep) && cand < keep)) { keep = cand; }
+                }
+                var name = acctToName[((meta[keep].fields || {}).reporter || {}).accountId];
+                if (name) { rows[name].resolved++; }
+            }
+        });
+    },
+
+    // ---- reports Attached / Trashed (reopen-aware, automation re-credited) ------------------------------
+    _isAutomation: function (author) {
+        if (!author) { return false; }
+        if (JiTA.credits.AUTOMATION_ID && author.accountId === JiTA.credits.AUTOMATION_ID) { return true; }
+        if ((author.emailAddress || '').toLowerCase() === JiTA.credits.AUTOMATION_EMAIL.toLowerCase()) { return true; }
+        return (author.displayName || '').toLowerCase().indexOf('automation for jira') !== -1;
+    },
+
+    _assigneeAt: function (histories, ts) {
+        var who = null;
+        for (var i = 0; i < histories.length; i++) {           // oldest-first
+            if ((histories[i].created || '') > ts) { break; }
+            var items = histories[i].items || [];
+            for (var j = 0; j < items.length; j++) { if (items[j].field === 'assignee') { who = items[j].to; } }
+        }
+        return who;
+    },
+
+    // accountId to credit for a report currently in target_status: author of the last (still-in-effect)
+    // transition into it, if in-month; automation transitions are re-credited to the assignee at that moment.
+    _effectiveActioner: function (histories, targetStatus, b) {
+        var last = null;
+        for (var i = 0; i < histories.length; i++) {
+            var items = histories[i].items || [];
+            for (var j = 0; j < items.length; j++) {
+                if (items[j].field !== 'status') { continue; }
+                last = items[j].toString === targetStatus ? histories[i] : null;   // else = undone by a later change
+            }
+        }
+        if (!last) { return null; }
+        var created = last.created || '';
+        if (!(b.start <= created.slice(0, 10) && created.slice(0, 10) < b.end)) { return null; }
+        var author = last.author || {};
+        return JiTA.credits._isAutomation(author) ? JiTA.credits._assigneeAt(histories, created) : author.accountId;
+    },
+
+    _reportsActioned: function (memberAccounts, b, rows, acctToName) {
+        var C = JiTA.credits, names = Object.keys(memberAccounts).sort();
+        var win = 'DURING ("' + b.start + '", "' + b.end + '")';
+        var movedOut = {};
+        // Reports that left Attached/Closed this month need their effective actioner resolved from the
+        // changelog (a close-then-reopen must not credit the reopener); the rest are direct BY-author counts.
+        return C._allKeys('project = ' + C.EBR + ' AND status CHANGED FROM "' + C.ATTACHED_STATUS + '" ' + win).then(function (a) {
+            return C._allKeys('project = ' + C.EBR + ' AND status CHANGED FROM "' + C.CLOSED_STATUS + '" ' + win).then(function (c) {
+                var k; for (k in a) { if (a.hasOwnProperty(k)) { movedOut[k] = true; } }
+                for (k in c) { if (c.hasOwnProperty(k)) { movedOut[k] = true; } }
+            });
+        }).then(function () {
+            return C._serial(names, function (name, i) {
+                C._pill('reports: member ' + (i + 1) + '/' + names.length + '  (' + name + ')');
+                if (i % 20 === 0 && window.console) { console.log('[JiTA] credits: reports ' + (i + 1) + '/' + names.length); }
+                var accs = memberAccounts[name];
+                var att = {}, clo = {};
+                var queries = [];
+                for (var i = 0; i < accs.length; i++) {
+                    queries.push({ tgt: att, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.ATTACHED_STATUS + '" BY "' + accs[i] + '" ' + win });
+                    queries.push({ tgt: clo, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.CLOSED_STATUS + '" BY "' + accs[i] + '" ' + win });
+                }
+                if (C.AUTOMATION_ID) {   // automation did the transition, but this member (assignee) triggered it
+                    var who = 'assignee in (' + C._accList(accs) + ')';
+                    queries.push({ tgt: att, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.ATTACHED_STATUS + '" BY "' + C.AUTOMATION_ID + '" ' + win + ' AND ' + who });
+                    queries.push({ tgt: clo, jql: 'project = ' + C.EBR + ' AND status CHANGED TO "' + C.CLOSED_STATUS + '" BY "' + C.AUTOMATION_ID + '" ' + win + ' AND ' + who });
+                }
+                return C._serial(queries, function (q) {
+                    return C._allKeys(q.jql).then(function (keys) { for (var kk in keys) { if (keys.hasOwnProperty(kk)) { q.tgt[kk] = true; } } });
+                }).then(function () {
+                    var a = 0, cc = 0;
+                    for (var kA in att) { if (att.hasOwnProperty(kA) && !movedOut[kA]) { a++; } }
+                    for (var kC in clo) { if (clo.hasOwnProperty(kC) && !movedOut[kC]) { cc++; } }
+                    rows[name].attached += a;
+                    rows[name].trashed += cc;
+                });
+            });
+        }).then(function () {
+            // Ambiguous (moved-out) reports: credit whoever's Attached/Closed transition is now in effect.
+            var movedKeys = Object.keys(movedOut);
+            if (movedKeys.length) { C._log('resolving ' + movedKeys.length + ' moved-out report(s) via changelog…'); }
+            return C._serial(movedKeys, function (k, i) {
+                C._pill('moved-out reports: ' + (i + 1) + '/' + movedKeys.length);
+                if (i % 50 === 0 && window.console) { console.log('[JiTA] credits: moved-out ' + (i + 1) + '/' + movedKeys.length); }
+                return JiTA.util.delay(C.CRAWL_DELAY_MS).then(function () { return C._allHistories(k); }).then(function (hist) {
+                    var an = acctToName[C._effectiveActioner(hist, C.ATTACHED_STATUS, b)];
+                    var cn = acctToName[C._effectiveActioner(hist, C.CLOSED_STATUS, b)];
+                    if (an) { rows[an].attached += 1; }
+                    if (cn) { rows[cn].trashed += 1; }
+                });
+            });
+        });
+    },
+
+    // ---- reports Reassigned to GM (Team -> GM changelog crawl, date-gated) -------------------------------
+    _autoReassigned: function (b, acctToName, rows) {
+        var C = JiTA.credits;
+        var jql = 'project = ' + C.EBR + ' AND ' + C.TEAM_JQL + ' = ' + C.GM_TEAM_ID + ' AND updated >= "' + b.start + '"';
+        return C._allKeys(jql).then(function (keySet) {
+            var keys = Object.keys(keySet);
+            C._log('reassign: crawling ' + keys.length + ' candidate report(s)…');
+            return C._serial(keys, function (k, i) {
+                C._pill('reassign: ' + (i + 1) + '/' + keys.length);
+                if (i % 50 === 0 && window.console) { console.log('[JiTA] credits: reassign ' + (i + 1) + '/' + keys.length); }
+                return JiTA.util.delay(C.CRAWL_DELAY_MS).then(function () {
+                    return C._get('/rest/api/3/issue/' + k + '?expand=changelog&fields=summary');
+                }).then(function (issue) {
+                    var credited = {};
+                    var hist = ((issue.changelog || {}).histories) || [];
+                    for (var i = 0; i < hist.length; i++) {
+                        var created = (hist[i].created || '').slice(0, 10);
+                        if (!(b.start <= created && created < b.end)) { continue; }   // in-month change only
+                        var items = hist[i].items || [];
+                        for (var j = 0; j < items.length; j++) {
+                            var it = items[j];
+                            var isTeam = it.fieldId === C.TEAM_CF || it.field === 'Team';
+                            var isGm = it.to === C.GM_TEAM_ID || it.to === C.GM_TEAM_FULL_ID || it.toString === C.GM_TEAM_NAME;
+                            if (isTeam && isGm) {
+                                var author = (hist[i].author || {}).accountId;
+                                if (author && !credited[author]) {
+                                    credited[author] = true;
+                                    var name = acctToName[author];
+                                    if (name) { rows[name].reassigned += 1; }
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+        }).catch(function (e) {
+            // Team-field JQL can fail (permissions / field ref); leave Reassigned at 0 rather than aborting.
+            if (window.console) { console.log('[JiTA] reassigned crawl skipped:', e && e.message || e); }
+        });
+    },
+
+    // ---- extra credits (lead bonus + optional mentor overrides) -----------------------------------------
+    _computeExtra: function (names, mentor) {
+        var out = {};
+        for (var i = 0; i < names.length; i++) {
+            var n = names[i];
+            var toks = {}; n.toLowerCase().replace(/-/g, ' ').split(/\s+/).forEach(function (t) { if (t) { toks[t] = true; } });
+            var e = 0;
+            for (var lead in JiTA.credits.LEADS) { if (JiTA.credits.LEADS.hasOwnProperty(lead) && toks[lead]) { e += JiTA.credits.LEAD_BONUS; } }
+            if (mentor) { for (var h in mentor) { if (mentor.hasOwnProperty(h) && toks[h]) { e += mentor[h]; } } }
+            if (e) { out[n] = e; }
+        }
+        return out;
+    },
+
+    // ---- orchestration ----------------------------------------------------------------------------------
+    // Compute the full per-member credit table for month (y, m). Resolves { ym, computedAt, header, table,
+    // rows, nameToAcc }. `table` rows are arrays aligned to `header` (last row is the Total).
+    computeMonth: function (y, m, mentor) {
+        var C = JiTA.credits, b = C._monthBounds(y, m);
+        var ym = b.start.slice(0, 7);
+        C._log(ym + ': resolving group members…');
+        return C._groupMembers().then(function (members) {
+            var active = members.filter(function (x) { return x.active !== false; });
+            return C._resolveOldReporters(active).then(function (old) {
+                var acctToName = {}, memberAccounts = {}, nameToAcc = {};
+                active.forEach(function (x) {
+                    acctToName[x.accountId] = x.displayName;
+                    (memberAccounts[x.displayName] = memberAccounts[x.displayName] || []).push(x.accountId);
+                    if (!nameToAcc[x.displayName]) { nameToAcc[x.displayName] = x.accountId; }
+                });
+                for (var oid in old.oldNames) {
+                    if (!old.oldNames.hasOwnProperty(oid)) { continue; }
+                    var nm = old.oldNames[oid];
+                    acctToName[oid] = nm;
+                    (memberAccounts[nm] = memberAccounts[nm] || []).push(oid);
+                }
+                var names = Object.keys(memberAccounts).sort();
+                var rows = {};
+                names.forEach(function (n) { rows[n] = { created: 0, resolved: 0, attached: 0, trashed: 0, reassigned: 0 }; });
+                var allAccounts = Object.keys(acctToName);
+
+                C._log(ym + ': ' + names.length + ' members - fetching defects…');
+                return C._defectsCreated(allAccounts, b, acctToName, rows)
+                    .then(function () { return C._defectsResolved(allAccounts, b, acctToName, rows); })
+                    .then(function () { C._log(ym + ': reports (attached / trashed)…'); return C._reportsActioned(memberAccounts, b, rows, acctToName); })
+                    .then(function () { C._log(ym + ': reassignments to GM…'); return C._autoReassigned(b, acctToName, rows); })
+                    .then(function () {
+                        var extras = C._computeExtra(names, mentor);
+                        var header = ['Name', 'Defects Created', 'Defects Resolved', 'Reports Attached',
+                            'Reports Trashed', 'Reports Reassigned', 'Total Actioned', 'Extra Credits', 'Credits Earned'];
+                        var table = [];
+                        var tot = { created: 0, resolved: 0, attached: 0, trashed: 0, reassigned: 0, actioned: 0, extra: 0, credits: 0 };
+                        names.forEach(function (n) {
+                            var r = rows[n], extra = extras[n] || 0;
+                            var actioned = r.attached + r.trashed + r.reassigned + r.created;
+                            var earned = C._creditFormula(r, extra);
+                            table.push([n, r.created, r.resolved, r.attached, r.trashed, r.reassigned, actioned, extra, earned]);
+                            tot.created += r.created; tot.resolved += r.resolved; tot.attached += r.attached;
+                            tot.trashed += r.trashed; tot.reassigned += r.reassigned; tot.actioned += actioned;
+                            tot.extra += extra; tot.credits += earned;
+                        });
+                        table.push(['Total', tot.created, tot.resolved, tot.attached, tot.trashed, tot.reassigned,
+                            tot.actioned, Math.round(tot.extra * 10) / 10, Math.round(tot.credits * 10) / 10]);
+                        return { ym: ym, computedAt: new Date().toISOString(), header: header, table: table, rows: rows, nameToAcc: nameToAcc };
+                    });
+            });
+        });
+    },
+
+    // ---- cache (meta store: credits:<YYYY-MM>) ----------------------------------------------------------
+    _cacheKey: function (ym) { return 'credits:' + ym; },
+    getCached: function (ym) { return JiTA.db.getMeta(JiTA.credits._cacheKey(ym)); },
+    putCached: function (result) { return JiTA.db.setMeta(JiTA.credits._cacheKey(result.ym), result); },
+
+    _ymNow: function () {
+        var d = new Date(), p2 = function (n) { return (n < 10 ? '0' : '') + n; };
+        return { y: d.getFullYear(), m: d.getMonth() + 1, ym: d.getFullYear() + '-' + p2(d.getMonth() + 1) };
+    },
+
+    // Compute a month + cache it. Guarded so two calls don't overlap. Resolves the result object.
+    refresh: function (y, m, mentor) {
+        if (JiTA.credits.running) { JiTA.ui.toast('A credit computation is already running…'); return Promise.resolve(null); }
+        JiTA.credits.running = true;
+        var t0 = Date.now();
+        return JiTA.credits.computeMonth(y, m, mentor).then(function (res) {
+            return JiTA.credits.putCached(res).then(function () {
+                JiTA.credits.running = false;
+                JiTA.credits._clearProgress();
+                JiTA.ui.setStatus('Credits ' + res.ym + ' ready (' + Math.round((Date.now() - t0) / 1000) + 's)');
+                return res;
+            });
+        }).catch(function (e) {
+            JiTA.credits.running = false;
+            JiTA.credits._clearProgress();
+            JiTA.ui.setStatus('Credits error: ' + (e && e.message || e));
+            throw e;
+        });
+    },
+
+    // ---- Phase 1a: manual trigger + console dump (verify against monthly_report.py) ---------------------
+    // Pretty-print the table to the console and return the current user's row + rank.
+    _report: function (res) {
+        var header = res.header, table = res.table;
+        // fixed-width console dump
+        var widths = header.map(function (h, i) {
+            return Math.max.apply(null, [String(h).length].concat(table.map(function (r) { return String(r[i]).length; })));
+        });
+        function line(row) {
+            return row.map(function (c, i) { var s = String(c); return i === 0 ? s + Array(widths[i] - s.length + 1).join(' ') : Array(widths[i] - s.length + 1).join(' ') + s; }).join('  ');
+        }
+        if (window.console) {
+            console.log('[JiTA] ISD credits ' + res.ym + ' (computed ' + res.computedAt + ')');
+            console.log(line(header));
+            table.forEach(function (r) { console.log(line(r)); });
+        }
+        return JiTA.link.currentUser().then(function (me) {
+            var myName = null;
+            for (var name in res.nameToAcc) { if (res.nameToAcc.hasOwnProperty(name) && res.nameToAcc[name] === me) { myName = name; } }
+            // rank among real members (exclude the Total row) by Credits Earned desc
+            var real = table.slice(0, -1).slice().sort(function (a, b) { return b[8] - a[8]; });
+            var myRow = null, myRank = null;
+            for (var i = 0; i < real.length; i++) { if (real[i][0] === myName) { myRow = real[i]; myRank = i + 1; } }
+            return { myName: myName, myRow: myRow, myRank: myRank, total: real.length };
+        });
+    },
+
+    runManual: function () {
+        var now = JiTA.credits._ymNow();
+        JiTA.ui.toast('Computing ISD credits for ' + now.ym + '… (see console; this can take a while)');
+        JiTA.credits.refresh(now.y, now.m).then(function (res) {
+            if (!res) { return; }
+            return JiTA.credits._report(res).then(function (mine) {
+                if (mine.myRow) {
+                    JiTA.ui.toast('Your credits ' + now.ym + ': ' + mine.myRow[8] + ' (rank ' + mine.myRank + '/' + mine.total + '). Full table in console.');
+                } else {
+                    JiTA.ui.toast('Credits ' + now.ym + ' computed (' + mine.total + ' members). Full table in console. (Your account was not matched to a member.)');
+                }
+            });
+        }).catch(function (e) {
+            alert('Credit computation failed: ' + (e && e.message || e) + '\nReport issues to Schogol :).');
+        });
     }
 };
 

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -7474,7 +7474,7 @@ JiTA.menu = {
                 .append($('<span class="sub"></span>').text('How often to recompute this month in the background'))
                 .appendTo($ivRow);
             var $iv = $('<select class="jita-cred-input" style="width:auto;"></select>');
-            [['Manual only', '0'], ['Every hour', '60'], ['Every 3 hours', '180'], ['Every 6 hours', '360'], ['Every 12 hours', '720'], ['Daily', '1440']]
+            [['Manual only', '0'], ['Every 5 minutes', '5'], ['Every 15 minutes', '15'], ['Every 30 minutes', '30'], ['Every hour', '60'], ['Every 3 hours', '180'], ['Every 6 hours', '360'], ['Every 12 hours', '720'], ['Every 24 hours', '1440']]
                 .forEach(function (o) { $('<option></option>').val(o[1]).text(o[0]).appendTo($iv); });
             $iv.val(String(JiTA.credits.sched.intervalMin()));
             $iv.on('change', function () { gmSet('creditsIntervalMin', parseInt($iv.val(), 10) || 0); });
@@ -8266,7 +8266,7 @@ JiTA.credits = {
         JiTA.credits._cssInjected = true;
         try {
             GM_addStyle(
-                '#jita-menu.jita-credits-view { width: 760px; max-width: 94vw; display: flex; flex-direction: column; overflow: hidden; }' +
+                '#jita-menu.jita-credits-view { width: 1180px; max-width: 96vw; display: flex; flex-direction: column; overflow: hidden; }' +
                 '#jita-menu.jita-credits-view .jita-menu-head { flex: 0 0 auto; }' +
                 '#jita-menu.jita-credits-view .jita-cred-scroll { flex: 1 1 auto; min-height: 0; max-height: 68vh; overflow-y: auto; padding: 8px 16px 12px; }' +
                 '#jita-menu.jita-credits-view .jita-cred-foot { flex: 0 0 auto; display: flex; flex-wrap: wrap; gap: 8px; align-items: center; padding: 10px 16px; border-top: 1px solid #3a434d; background: #282d33; }' +
@@ -8340,7 +8340,9 @@ JiTA.credits = {
             var $hr = $('<tr></tr>');
             $('<th style="text-align:left;padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;">#</th>').appendTo($hr);
             h.forEach(function (c, i) {
-                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(c).appendTo($hr);
+                // Short column labels so all 9 columns fit without horizontal scroll (the card shows the full names).
+                var lbl = c.replace(/^Defects |^Reports |^Total /, '').replace(/ Credits$| Earned$/, '');
+                $('<th></th>').attr('style', 'padding:5px 8px;border-bottom:1px solid #3a434d;color:#9aa6b2;white-space:nowrap;text-align:' + (i === 0 ? 'left' : 'right') + ';').text(lbl).appendTo($hr);
             });
             $tbl.append($('<thead></thead>').append($hr));
             var $tb = $('<tbody></tbody>');
@@ -8431,15 +8433,16 @@ JiTA.credits = {
 
     // ---- background scheduler (throttled current-month recompute; interval is user-configurable) ----------
     sched: {
-        POLL_MS: 5 * 60 * 1000,          // how often we CHECK whether the interval has elapsed
+        POLL_MS: 60 * 1000,              // check every minute (so even a 5-minute interval is honored closely)
         STARTUP_DELAY_MS: 25 * 1000,     // let the page settle before the first (possibly heavy) run
-        LEASE_TTL_MS: 20 * 60 * 1000,    // a full compute can take minutes; treat an older lease as abandoned
+        LEASE_TTL_MS: 90 * 1000,         // lease is heartbeated every 30s while computing; a dead tab's lease expires ~90s after it stops
+        HEARTBEAT_MS: 30 * 1000,
         LAST_KEY: 'creditsLastTs',
         LEASE_KEY: 'creditsLease',
         _timer: null,
 
         // Auto-update interval in MINUTES, read live from GM storage (0 = manual only). Set from the settings menu.
-        intervalMin: function () { var v = parseInt(gmGet('creditsIntervalMin', 180), 10); return isNaN(v) ? 180 : v; },
+        intervalMin: function () { var v = parseInt(gmGet('creditsIntervalMin', 15), 10); return isNaN(v) ? 15 : v; },
 
         _recently: function () {
             var iv = JiTA.credits.sched.intervalMin();
@@ -8456,27 +8459,45 @@ JiTA.credits = {
             return false;
         },
         tick: function () {
+            var S = JiTA.credits.sched;
             if (!savedVariables[3][1]) { return; }                 // feature off
             try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }   // cheap: reflect the latest cache
             if (JiTA.credits.running) { return; }
-            if (JiTA.credits.sched._recently()) { return; }        // interval not elapsed (or manual-only)
-            if (!JiTA.credits.sched._lease()) { return; }          // another tab is computing
+            if (S._recently()) { return; }                         // interval not elapsed (or manual-only)
+            if (!S._lease()) { return; }                           // another tab is computing
             var now = JiTA.credits._ymNow();
             JiTA.credits._quiet = true;                            // background run: no floating pill
             try { var b = document.getElementById('jita-credits-badge'); if (b) { b.textContent = '📊 updating…'; } } catch (e) { /* ignore */ }
+            // Heartbeat the lease while computing. The compute is in-memory and only writes its result on
+            // completion, so an interrupted run (tab refresh/close) leaves NO partial data and simply restarts
+            // next cycle. The heartbeat means a dead tab's lease goes stale in ~90s (vs. the full TTL), so the
+            // reloaded/other tab picks the work back up promptly instead of skipping cycles.
+            var hb = setInterval(function () { gmSet(S.LEASE_KEY, { tabId: JiTA.sched.tabId, ts: Date.now() }); }, S.HEARTBEAT_MS);
+            var stop = function () { clearInterval(hb); };
             JiTA.credits.refresh(now.y, now.m).then(function () {
-                gmSet(JiTA.credits.sched.LAST_KEY, Date.now());
+                gmSet(S.LAST_KEY, Date.now());
+                gmSet(S.LEASE_KEY, null);   // release on success
                 try { JiTA.credits.badge.refresh(); } catch (e) { /* ignore */ }
-            }).catch(function () { /* swallow; retry next window */ });
+                stop();
+            }).catch(function () { stop(); });   // heartbeat stops -> lease expires -> retry next window
         },
         start: function () {
-            if (JiTA.credits.sched._timer) { return; }
+            var S = JiTA.credits.sched;
+            if (S._timer) { return; }
+            // Release our lease when the tab goes away (refresh / close / navigate) so a reload can recompute at
+            // once instead of waiting out the TTL. Best-effort; the heartbeat + TTL are the backstop if it doesn't fire.
+            try {
+                window.addEventListener('pagehide', function () {
+                    var l = gmGet(S.LEASE_KEY, null);
+                    if (l && l.tabId === JiTA.sched.tabId) { gmSet(S.LEASE_KEY, null); }
+                });
+            } catch (e) { /* ignore */ }
             setTimeout(function () {
-                try { JiTA.credits.sched.tick(); } catch (e) { /* swallow */ }
-                JiTA.credits.sched._timer = setInterval(function () {
-                    try { JiTA.credits.sched.tick(); } catch (e) { /* swallow */ }
-                }, JiTA.credits.sched.POLL_MS);
-            }, JiTA.credits.sched.STARTUP_DELAY_MS);
+                try { S.tick(); } catch (e) { /* swallow */ }
+                S._timer = setInterval(function () {
+                    try { S.tick(); } catch (e) { /* swallow */ }
+                }, S.POLL_MS);
+            }, S.STARTUP_DELAY_MS);
         }
     },
 


### PR DESCRIPTION
## Summary

This branch introduces the **ISD credits tracker** and, on top of it, the **3.0 shared-worker refactor** that moves the embedding model, all ranking indexes, and the credits crawl out of every tab into a single worker.

### ISD credits tracker
- In-browser monthly compute engine (defects created/resolved with clone dedup, reports attached/trashed with reopen-aware effective-actioner resolution, GM reassignments, credit formula).
- Always-on corner **badge** (your current-month total + rank) and a **leaderboard overlay** with a month selector.
- Background scheduler: your own total recomputes every ~2 min, the full leaderboard every ~15 min, cross-tab lease so only one tab runs the heavy crawl.

### 3.0 shared worker (leader-elected via Web Locks, one per origin)
Fixes per-tab RAM/VRAM multiplication (one model + indexes for **all** tabs instead of one set per tab) and background-timer throttling of the credits crawl.
- Hosts the embedding model + semantic / BM25 / logsig ranking indexes; tabs become thin clients holding no ranking state.
- Runs the credits monthly crawl via **same-origin fetch** with the politeness sleeps off the main thread, so an unfocused/hidden tab no longer stalls a refresh.
- **Single-flights + coalesces** the credits crawl so two tabs (e.g. a scheduled run + a manual Refresh) never crawl the same month at once - fixes doubled REST load and the jumping progress pill.

### Leaderboard UI
- Full leaderboard visible to everyone.
- Neutral card title for uncomputed months; accurate "not computed yet" wording (only the current month auto-refreshes).
- Warns that older months compute slower (unbounded GM-reassign crawl).
- Badge shows "Credits" instead of "cr".

Also removes the now-dead local ranking path and the dev-only menu commands.