### PR TITLE
Triage improvements: dup-reports section + quick wins (v3.7.0)

### DIFF
--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Jira Triage Assistant
-// @version     3.6.4
+// @version     3.7.0
 // @author      ISD BH Schogol, ISD Tulwar
 // @description Adds a Translate, Assign to GM, Convert to Defect and Close button to Jira, parses Log Files submitted from the EVE client, suggests similar existing defects on bug reports, and (on a defect) lists the open bug reports that best match it
 // @updateURL   https://github.com/Schogol/Jira-Triage-Assistant/raw/main/JiTA.user.js
@@ -5973,10 +5973,18 @@ JiTA.ui = {
 #jita-sd-loglink a:hover { text-decoration: underline; }\
 #jita-sd-loglink .count { color: #cfd6dd; background: #3a434d; border-radius: 8px; padding: 0 7px; font-size: 10px; font-weight: 700; margin-left: 6px; }\
 .jita-sd-loose { font-size: 10px; color: #9aa6b2; margin-left: 6px; }\
+#jita-sd-ebrdups { display: none; padding: 6px 10px; border-bottom: 1px solid #2c333a; background: #20262b; }\
+#jita-sd-ebrdups.has-hits { display: block; }\
+#jita-sd-ebrdups .jita-sd-ebrdups-head { font-weight: 700; color: #6bd0dc; font-size: 11px; margin-bottom: 4px; }\
+#jita-sd-ebrdups ul { list-style: none; margin: 0; padding: 0; }\
+#jita-sd-ebrdups li { padding: 3px 0; cursor: default; }\
+#jita-sd-ebrdups a { color: #4c9aff; font-weight: 700; text-decoration: none; }\
+#jita-sd-ebrdups a:hover { text-decoration: underline; }\
+#jita-sd-ebrdups .jita-sd-ebrdups-sum { color: #cfd6dd; font-size: 11px; margin-left: 6px; }\
 #jita-sd-exccluster { display: none; padding: 6px 10px; border-bottom: 1px solid #2c333a; background: #20262b; }\
 #jita-sd-exccluster.has-hits { display: block; }\
 #jita-sd-exccluster .jita-sd-exccluster-head { font-weight: 700; color: #cfd6dd; font-size: 11px; margin-bottom: 4px; }\
-#jita-sd-panel.collapsed #jita-sd-status, #jita-sd-panel.collapsed #jita-sd-loglink, #jita-sd-panel.collapsed #jita-sd-exccluster, #jita-sd-panel.collapsed #jita-sd-list { display: none; }\
+#jita-sd-panel.collapsed #jita-sd-status, #jita-sd-panel.collapsed #jita-sd-loglink, #jita-sd-panel.collapsed #jita-sd-ebrdups, #jita-sd-panel.collapsed #jita-sd-exccluster, #jita-sd-panel.collapsed #jita-sd-list { display: none; }\
 #jita-sd-panel.jita-sd-up { flex-direction: column-reverse; }\
 #jita-sd-toast { position: fixed; right: 18px; bottom: 18px; z-index: 9001; background: #333; color: #eee; padding: 8px 14px;\
   border-radius: 6px; box-shadow: 0 4px 18px rgba(0,0,0,.45); font-family: -apple-system,Arial,sans-serif; font-size: 12px; max-width: 320px; }\
@@ -6037,6 +6045,11 @@ JiTA.ui = {
 #jita-side-group #jita-sd-loglink { display: none; padding: 6px 0; border-bottom: 1px solid var(--ds-border, #091e4224); background: transparent; }\
 #jita-side-group #jita-sd-loglink.has-hits { display: block; }\
 #jita-side-group #jita-sd-loglink .jita-sd-loglink-head { color: var(--ds-text-warning, #974f0c); }\
+#jita-side-group #jita-sd-ebrdups { display: none; padding: 6px 0; border-bottom: 1px solid var(--ds-border, #091e4224); background: transparent; }\
+#jita-side-group #jita-sd-ebrdups.has-hits { display: block; }\
+#jita-side-group #jita-sd-ebrdups .jita-sd-ebrdups-head { color: var(--ds-text, #172b4d); }\
+#jita-side-group #jita-sd-ebrdups .jita-sd-ebrdups-sum { color: var(--ds-text-subtle, #44546f); }\
+#jita-side-group #jita-sd-ebrdups a { color: var(--ds-link, #0c66e4); }\
 #jita-side-group #jita-sd-exccluster { display: none; padding: 6px 0; border-bottom: 1px solid var(--ds-border, #091e4224); background: transparent; }\
 #jita-side-group #jita-sd-exccluster.has-hits { display: block; }\
 #jita-side-group #jita-sd-exccluster .jita-sd-exccluster-head { color: var(--ds-text, #172b4d); }\
@@ -6675,6 +6688,7 @@ JiTA.ui = {
             '    <span id="jita-sd-collapse" title="Collapse / expand">–</span></div>' +
             '  <div id="jita-sd-status"></div>' +
             '  <div id="jita-sd-loglink"></div>' +
+            '  <div id="jita-sd-ebrdups"></div>' +
             '  <div id="jita-sd-exccluster"></div>' +
             '  <ul id="jita-sd-list"></ul>' +
             '</div>'
@@ -6710,6 +6724,7 @@ JiTA.ui = {
                '<span id="jita-sd-mode" title="Click to switch ranking mode (resets to automatic on reload)">Keyword</span></div>' +
                '<div id="jita-sd-status"></div>' +
                '<div id="jita-sd-loglink"></div>' +
+               '<div id="jita-sd-ebrdups"></div>' +
                '<div id="jita-sd-exccluster"></div>' +
                '<ul id="jita-sd-list"></ul>';
     },
@@ -7426,6 +7441,54 @@ JiTA.ui = {
         });
     },
 
+    // EBR view extra section: OTHER open bug reports that closely match THIS report - likely a player filing the
+    // same bug again. Same engine as the defect view's "matching reports" (suggestEbrBest over the EBR index),
+    // excluding self, filtered to strong matches, top few, in its own #jita-sd-ebrdups box above the similar-
+    // defects list. Rows open in a new tab and share the suggestions' hover preview; no attach control (both sides
+    // are reports). Mirrors renderLogLink's background/atomic-refill so it never flashes on a data-driven refresh.
+    EBR_DUP_LIMIT: 5,
+    EBR_DUP_MIN_PCT: 40,   // drop weak matches so an unrelated report doesn't show phantom "duplicates"
+    renderEbrDups: function (key, background) {
+        var $box = $('#jita-sd-ebrdups');
+        if (!$box.length) { return; }
+        if (!background) { $box.removeClass('has-hits').empty(); }
+        JiTA.db.countEbr().then(function (n) {
+            if (!n) { $box.removeClass('has-hits').empty(); return; }
+            return JiTA.ui.getIssueText(key).then(function (text) {
+                if (JiTA.ui.currentKey !== key) { return; }
+                if (!text) { $box.removeClass('has-hits').empty(); return; }
+                return JiTA.rank.suggestEbrBest(text, key, JiTA.ui.modeOverride, JiTA.ui._filterTerms()).then(function (out) {
+                    if (JiTA.ui.currentKey !== key) { return; }
+                    var results = (out.results || []).filter(function (r) { return (r.pct || 0) >= JiTA.ui.EBR_DUP_MIN_PCT; }).slice(0, JiTA.ui.EBR_DUP_LIMIT);
+                    var $b = $('#jita-sd-ebrdups');
+                    if (!results.length) { $b.removeClass('has-hits').empty(); return; }   // genuinely no strong dup now -> clear (covers the background path that skipped the top empty)
+                    return Promise.all(results.map(function (r) {
+                        return JiTA.db.getDefect(r.key).then(function (rec) {
+                            if (rec) { r.description = rec.description; r.created = rec.created; }
+                            return r;
+                        }, function () { return r; });
+                    })).then(function () {
+                        if (JiTA.ui.currentKey !== key) { return; }
+                        $b.empty();
+                        $('<div class="jita-sd-ebrdups-head"></div>').text('⧉ Possible duplicate reports (' + results.length + ')').appendTo($b);
+                        var $ul = $('<ul></ul>').appendTo($b);
+                        results.forEach(function (r) {
+                            var $li = $('<li></li>').attr('data-jita-key', r.key);
+                            $('<a></a>').attr('href', '/browse/' + r.key).attr('target', '_blank').text(r.key).appendTo($li);
+                            if (typeof r.pct === 'number') { $('<span class="jita-sd-score"></span>').text(r.pct + '%').appendTo($li); }
+                            $('<span class="jita-sd-ebrdups-sum"></span>').text(r.summary || '').attr('title', r.summary || '').appendTo($li);
+                            $li.on('mouseenter', function () { JiTA.ui._showTip(r, this, r.status || ''); });
+                            $li.on('mouseleave', function () { JiTA.ui._hideTip(); });
+                            $ul.append($li);
+                        });
+                        $b.addClass('has-hits');
+                        JiTA.ui._fitVertical();
+                    });
+                });
+            });
+        }).catch(function () { /* leave the section as-is on error */ });
+    },
+
     // Coalesce re-render requests. A single sync drives several "refresh the list" triggers in quick
     // succession - the sync's own completion, then embed.prepare()'s completion after the embed pass, and
     // (for autoSync) both the defect and EBR legs - and each render() empties + refills #jita-sd-list, so the
@@ -7459,6 +7522,7 @@ JiTA.ui = {
             md = document.getElementById('jita-sd-mode'),
             ti = document.getElementById('jita-sd-title'),
             ll = document.getElementById('jita-sd-loglink'),
+            eb = document.getElementById('jita-sd-ebrdups'),
             ex = document.getElementById('jita-sd-exccluster');
         JiTA.ui._snapshot = {
             key: key,
@@ -7468,6 +7532,8 @@ JiTA.ui = {
             title: ti ? ti.textContent : '',
             loglink: ll ? ll.innerHTML : '',
             loglinkHits: !!(ll && ll.className.indexOf('has-hits') !== -1),
+            ebrdups: eb ? eb.innerHTML : '',
+            ebrdupsHits: !!(eb && eb.className.indexOf('has-hits') !== -1),
             exccluster: ex ? ex.innerHTML : '',
             exclusterHits: !!(ex && ex.className.indexOf('has-hits') !== -1)
         };
@@ -7494,6 +7560,11 @@ JiTA.ui = {
         if (ll) {
             ll.innerHTML = s.loglink || '';
             if (s.loglinkHits) { ll.classList.add('has-hits'); } else { ll.classList.remove('has-hits'); }
+        }
+        var eb = document.getElementById('jita-sd-ebrdups');
+        if (eb) {
+            eb.innerHTML = s.ebrdups || '';
+            if (s.ebrdupsHits) { eb.classList.add('has-hits'); } else { eb.classList.remove('has-hits'); }
         }
         var ex = document.getElementById('jita-sd-exccluster');
         if (ex) {
@@ -7526,6 +7597,7 @@ JiTA.ui = {
         $('#jita-sd-title').text('Similar defects');   // reset title (the panel is shared with the EDR reports view)
         $('#jita-sd-exccluster').removeClass('has-hits').empty();   // defect-only section; clear it on the EBR view
         JiTA.ui.renderLogLink(key, background);   // scan the attached log for known defects (no need to open it); background = don't blank it first
+        JiTA.ui.renderEbrDups(key, background);    // OTHER open reports that look like duplicates of this one
         if (!background) { $('#jita-sd-list').empty(); JiTA.ui.setStatus('Finding similar defects…'); }
         JiTA.ui.getIssueText(key).then(function (text) {
             return JiTA.db.countDefectsOnly().then(function (n) {
@@ -7569,6 +7641,7 @@ JiTA.ui = {
         var terms = JiTA.ui._filterTerms();   // filter box: restrict the ranked corpus to these terms (whole DB)
         $('#jita-sd-title').text('Matching bug reports');
         $('#jita-sd-loglink').removeClass('has-hits').empty();   // EBR-only section; unused on a defect
+        $('#jita-sd-ebrdups').removeClass('has-hits').empty();   // EBR-only section; unused on a defect
         if (!background) { $('#jita-sd-list').empty(); }   // background refresh keeps the list until new results are ready
         JiTA.ui.renderExceptionCluster(key, background);   // list other defects that reported the same exception; background = don't blank it first
         if (!background) { JiTA.ui.setStatus('Finding matching bug reports…'); }
@@ -7613,6 +7686,7 @@ JiTA.ui = {
         $('#jita-sd-mode').text('');                                  // no ranking mode in this view
         $('#jita-sd-exccluster').removeClass('has-hits').empty();     // defect-only section
         $('#jita-sd-loglink').removeClass('has-hits').empty();        // similar-defects-only section
+        $('#jita-sd-ebrdups').removeClass('has-hits').empty();        // dup-reports section, not shown in this view
         $('#jita-sd-list').empty();
         JiTA.ui.setStatus('Finding this reporter’s other reports…');
         JiTA.ui._getReporterId(key).then(function (rid) {

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Jira Triage Assistant
-// @version     3.6.3
+// @version     3.6.4
 // @author      ISD BH Schogol, ISD Tulwar
 // @description Adds a Translate, Assign to GM, Convert to Defect and Close button to Jira, parses Log Files submitted from the EVE client, suggests similar existing defects on bug reports, and (on a defect) lists the open bug reports that best match it
 // @updateURL   https://github.com/Schogol/Jira-Triage-Assistant/raw/main/JiTA.user.js
@@ -955,7 +955,19 @@ waitForKeyElements(cmSelector, SwapUI);
             }
         }
     }
-    try { new MutationObserver(hideLogs).observe(document.body, { childList: true, subtree: true, characterData: true }); } catch (e) { /* ignore */ }
+    try {
+        new MutationObserver(function (records) {
+            // Cheap gate before the full-document scan: a comment-typing keystroke is a characterData-only mutation
+            // with no parse pending - skip those. Scan only when a node was actually added (a log may have mounted)
+            // or a header-less parse is pending (its raw text streams in via characterData).
+            if (!jitaParserPending) {
+                var added = false;
+                for (var i = 0; i < records.length; i++) { if (records[i].addedNodes && records[i].addedNodes.length) { added = true; break; } }
+                if (!added) { return; }
+            }
+            hideLogs();
+        }).observe(document.body, { childList: true, subtree: true, characterData: true });
+    } catch (e) { /* ignore */ }
 })();
 
 
@@ -2937,7 +2949,7 @@ JiTA.logsig = {
         text = text.replace(/^[ \t]*\d{1,2}:\d{2}:\d{2}\t[^\t\n]*\t[^\t\n]*\t/gm, '');
         var msg = '', mm = /Formatted exception info\s*:?\s*([\s\S]*?)(?:\bCommon path prefix\b|\bCaught at\b|\bThrown at\b|\bReported from\b|\bThread Locals\b|\bStackhash\b|\bEXCEPTION END\b|$)/i.exec(text);
         if (mm) { msg = (mm[1] || '').replace(/\s+/g, ' ').trim(); }
-        var frames = [], fre = /([A-Za-z0-9_.\/\\-]+\.py)\((\d+)\)\s+([A-Za-z0-9_<>]+)/g, fm;
+        var frames = [], fre = /([A-Za-z0-9_.\/\\-]+\.pyx?)\((\d+)\)\s+([A-Za-z0-9_<>]+)/g, fm;   // .py OR .pyx (EVE's Cython frames)
         while ((fm = fre.exec(text))) {
             frames.push(fm[1].replace(/^.*[\/\\]/, '') + ':' + fm[3]);   // basename:function (no line number)
         }
@@ -6066,6 +6078,18 @@ JiTA.ui = {
 
     setStatus: function (msg) { $('#jita-sd-status').text(msg); },
 
+    // Status message with an inline action link (e.g. "Sync now" in an empty state, "Retry" after an error) - one
+    // click instead of "read a sentence, then go hunt the Tampermonkey menu".
+    setStatusAction: function (msg, label, fn) {
+        var $s = $('#jita-sd-status');
+        if (!$s.length) { return; }
+        $s.empty().append(document.createTextNode(msg + ' '));
+        $('<a href="#"></a>').text(label)
+            .css({ 'text-decoration': 'underline', cursor: 'pointer', color: '#4c9aff' })
+            .on('click', function (e) { e.preventDefault(); try { fn(); } catch (x) { /* ignore */ } })
+            .appendTo($s);
+    },
+
     // ---- live filter box + clickable ranking-mode badge (left of the Keyword/Hybrid label) ----
     // The filter re-QUERIES the whole local database (not just the rows already on screen): the typed word(s)
     // are pushed into the ranker as a hard pre-filter, so it picks the best TOP_N matches from EVERY stored
@@ -7506,7 +7530,7 @@ JiTA.ui = {
         JiTA.ui.getIssueText(key).then(function (text) {
             return JiTA.db.countDefectsOnly().then(function (n) {
                 if (!n) {
-                    JiTA.ui.setStatus('No local data yet – open the Tampermonkey menu and click “Sync defects now”.');
+                    JiTA.ui.setStatusAction('No local data yet.', 'Sync defects now', function () { JiTA.sync.syncAllNow(); });
                     return;
                 }
                 if (!text) { JiTA.ui.setStatus('Could not read this issue’s text.'); return; }
@@ -7534,7 +7558,7 @@ JiTA.ui = {
                 });
                 });
             });
-        }).catch(function (e) { JiTA.ui.setStatus('Error: ' + (e && e.message || e)); });
+        }).catch(function (e) { JiTA.ui.setStatusAction('Error: ' + (e && e.message || e), 'Retry', function () { JiTA.ui._rerenderCurrent(); }); });
     },
 
     // EDR (defect) view: rank the OPEN bug reports that best match this defect's description (keyword BM25),
@@ -7551,7 +7575,7 @@ JiTA.ui = {
         JiTA.ui.getIssueText(key).then(function (text) {
             return JiTA.db.countEbr().then(function (n) {
                 if (!n) {
-                    JiTA.ui.setStatus('No bug reports synced yet – open the Tampermonkey menu and click “Sync bug reports now”.');
+                    JiTA.ui.setStatusAction('No bug reports synced yet.', 'Sync bug reports now', function () { JiTA.sync.syncAllNow(); });
                     return;
                 }
                 if (!text) { JiTA.ui.setStatus('Could not read this defect’s text.'); return; }
@@ -7575,7 +7599,7 @@ JiTA.ui = {
                     });
                 });
             });
-        }).catch(function (e) { JiTA.ui.setStatus('Error: ' + (e && e.message || e)); });
+        }).catch(function (e) { JiTA.ui.setStatusAction('Error: ' + (e && e.message || e), 'Retry', function () { JiTA.ui._rerenderCurrent(); }); });
     },
 
     // EBR view, "reporter's other reports" mode (funnel toggle): list EVERY other bug report from the same
@@ -7622,7 +7646,7 @@ JiTA.ui = {
                 for (var j = 0; j < rows.length; j++) { $list.append(JiTA.ui._reporterRow(rows[j])); }
                 JiTA.ui._fitVertical();
             });
-        }).catch(function (e) { JiTA.ui.setStatus('Error: ' + (e && e.message || e)); });
+        }).catch(function (e) { JiTA.ui.setStatusAction('Error: ' + (e && e.message || e), 'Retry', function () { JiTA.ui._rerenderCurrent(); }); });
     },
 
     // Wrap a value as a JQL string literal (escape backslashes + double-quotes).
@@ -8750,7 +8774,7 @@ function jitaWorkerBody(cfg) {
         text = (text || '').replace(/^[ \t]*\d{1,2}:\d{2}:\d{2}\t[^\t\n]*\t[^\t\n]*\t/gm, '');
         var msg = '', mm = /Formatted exception info\s*:?\s*([\s\S]*?)(?:\bCommon path prefix\b|\bCaught at\b|\bThrown at\b|\bReported from\b|\bThread Locals\b|\bStackhash\b|\bEXCEPTION END\b|$)/i.exec(text);
         if (mm) { msg = (mm[1] || '').replace(/\s+/g, ' ').trim(); }
-        var frames = [], fre = /([A-Za-z0-9_.\/\\-]+\.py)\((\d+)\)\s+([A-Za-z0-9_<>]+)/g, fm;
+        var frames = [], fre = /([A-Za-z0-9_.\/\\-]+\.pyx?)\((\d+)\)\s+([A-Za-z0-9_<>]+)/g, fm;   // .py OR .pyx (EVE's Cython frames)
         while ((fm = fre.exec(text))) { frames.push(fm[1].replace(/^.*[\/\\]/, '') + ':' + fm[3]); }
         var nmsg = msg.replace(/0x[0-9a-fA-F]+/g, '0x#').replace(/\b\d+L\b/g, '#').replace(/([(\[{,]\s*)\d+/g, '$1#').replace(/\d+(\s*[)\]},])/g, '#$1').replace(/\b\d{4,}\b/g, '#');
         var sig = frames.length >= LG_MIN ? (nmsg + '|' + frames.join('>')).toLowerCase() : null;

--- a/JiTA.user.js
+++ b/JiTA.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name        Jira Triage Assistant
-// @version     3.7.0
+// @version     3.7.1
 // @author      ISD BH Schogol, ISD Tulwar
 // @description Adds a Translate, Assign to GM, Convert to Defect and Close button to Jira, parses Log Files submitted from the EVE client, suggests similar existing defects on bug reports, and (on a defect) lists the open bug reports that best match it
 // @updateURL   https://github.com/Schogol/Jira-Triage-Assistant/raw/main/JiTA.user.js
@@ -5942,6 +5942,9 @@ JiTA.ui = {
 #jita-sd-filterbtn:hover { color: #e6e6e6; background: #3a434d; }\
 #jita-sd-filterbtn.active { color: #4c9aff; }\
 #jita-sd-filterbtn.active::after { content: ""; position: absolute; top: 1px; right: 1px; width: 5px; height: 5px; border-radius: 50%; background: #4c9aff; }\
+#jita-sd-dupbtn { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 6px; color: #9aa6b2; cursor: pointer; user-select: none; position: relative; flex: 0 0 auto; }\
+#jita-sd-dupbtn:hover { color: #e6e6e6; background: #3a434d; }\
+#jita-sd-dupbtn.active { color: #6bd0dc; }\
 #jita-sd-filtermenu { position: fixed; z-index: 10002; background: #14181b; color: #e6e6e6; border: 1px solid #3a434d; border-radius: 6px; box-shadow: 0 6px 24px rgba(0,0,0,.55); padding: 10px; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif; font-size: 12px; min-width: 190px; }\
 #jita-sd-filtermenu .jita-fm-label { color: #9aa6b2; font-size: 10px; text-transform: uppercase; letter-spacing: .04em; margin: 2px 0 5px; }\
 #jita-sd-filtermenu .jita-fm-seg { display: flex; margin-bottom: 10px; border: 1px solid #3a434d; border-radius: 6px; overflow: hidden; }\
@@ -6039,6 +6042,9 @@ JiTA.ui = {
 #jita-side-group #jita-sd-filterbtn:hover { color: var(--ds-text, #172b4d); background: var(--ds-background-neutral, #091e420f); }\
 #jita-side-group #jita-sd-filterbtn.active { color: var(--ds-link, #0c66e4); }\
 #jita-side-group #jita-sd-filterbtn.active::after { background: var(--ds-link, #0c66e4); }\
+#jita-side-group #jita-sd-dupbtn { color: var(--ds-text-subtle, #44546f); }\
+#jita-side-group #jita-sd-dupbtn:hover { color: var(--ds-text, #172b4d); background: var(--ds-background-neutral, #091e420f); }\
+#jita-side-group #jita-sd-dupbtn.active { color: var(--ds-link, #0c66e4); }\
 #jita-side-group #jita-sd-filter { background: var(--ds-surface, #fff); color: var(--ds-text, #172b4d); border-color: var(--ds-border-input, #8590a2); }\
 #jita-side-group #jita-sd-filter:focus { border-color: var(--ds-border-focused, #388bff); }\
 #jita-side-group #jita-sd-status { padding: 4px 0; border-bottom: none; color: var(--ds-text-subtlest, #626f86); }\
@@ -6124,6 +6130,15 @@ JiTA.ui = {
             if (document.getElementById('jita-sd-filtermenu')) { JiTA.ui._closeFilterMenu(); }
             else { JiTA.ui._showFilterMenu(this); }
         });
+        // Duplicate-reports toggle: flip the persisted preference, reflect it on the button, and (on an EBR) show
+        // or clear the "possible duplicate reports" section right away.
+        $(document).on('click', '#jita-sd-dupbtn', function (e) {
+            e.preventDefault(); e.stopPropagation();
+            gmSet('sdDupReports', !JiTA.ui._dupOn());
+            JiTA.ui._syncDupBtn(true);
+            var k = JiTA.ui.currentKey;
+            if (k && /^EBR-/.test(k)) { JiTA.ui.renderEbrDups(k); }   // recompute now, or clear if just turned off
+        });
         // Debounced re-query as the user types. (We previously tried to keep Jira from flagging the page as
         // having "unsubmitted changes" - it warns on reload because the filter input lives inside its issue
         // view - but the detection runs ahead of anything we can intercept, so we just accept the warning.)
@@ -6201,6 +6216,18 @@ JiTA.ui = {
     _syncFilterBtn: function () {
         var $b = $('#jita-sd-filterbtn');
         if ($b.length) { $b.toggleClass('active', JiTA.ui._filtersActive()); }
+    },
+
+    // Duplicate-reports toggle (two-squares icon, EBR view only). OFF by default: the "possible duplicate reports"
+    // section is gated behind this button so it costs nothing and adds no clutter until the triager asks for it.
+    // Persisted in GM ('sdDupReports') so the preference sticks across reloads.
+    _dupSvg: '<svg viewBox="0 0 16 16" width="12" height="12" fill="currentColor" aria-hidden="true"><path d="M5 1a1 1 0 0 0-1 1v1H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1v-1h1a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H5zm7 1v8h-1V4a1 1 0 0 0-1-1H5V2h7zM3 4h7v9H3V4z"/></svg>',
+    _dupOn: function () { return !!gmGet('sdDupReports', false); },
+    _syncDupBtn: function (show) {
+        var $b = $('#jita-sd-dupbtn');
+        if (!$b.length) { return; }
+        $b.css('display', show ? '' : 'none');   // EBR-only control
+        $b.toggleClass('active', JiTA.ui._dupOn());
     },
 
     // Build + show the filter popover under the funnel button. Rebuilt each open so it can be view-aware
@@ -6607,7 +6634,7 @@ JiTA.ui = {
             if (e.which && e.which !== 1) { return; }                 // left button only
             if ($(e.target).closest('#jita-sd-collapse').length) { return; }  // let the collapse toggle work
             if ($(e.target).closest('#jita-sd-filter').length) { return; }    // let the filter input take focus / select text
-            if ($(e.target).closest('#jita-sd-filterbtn').length) { return; } // let the funnel open the filter popover
+            if ($(e.target).closest('#jita-sd-filterbtn, #jita-sd-dupbtn').length) { return; } // let the funnel / dup toggle handle their own clicks
             if ($(e.target).closest('#jita-sd-mode').length) { return; }      // let the mode badge toggle ranking
             // Drag relative to the HEADER's current top (works whether we're top-anchored or in drop-up),
             // so the header tracks the cursor and _fitVertical re-evaluates up/down on every move.
@@ -6684,6 +6711,7 @@ JiTA.ui = {
             '  <div id="jita-sd-head"><span id="jita-sd-title">Similar defects</span>' +
             '    <input id="jita-sd-filter" type="text" placeholder="Filter…" autocomplete="off" title="Filter the whole database by this text (key / title / description) and show the best matches">' +
             '    <span id="jita-sd-filterbtn" title="Filter results (status / recency)">' + JiTA.ui._funnelSvg + '</span>' +
+            '    <span id="jita-sd-dupbtn" style="display:none" title="Show possible duplicate reports">' + JiTA.ui._dupSvg + '</span>' +
             '    <span id="jita-sd-mode" title="Click to switch ranking mode (resets to automatic on reload)">Keyword</span>' +
             '    <span id="jita-sd-collapse" title="Collapse / expand">–</span></div>' +
             '  <div id="jita-sd-status"></div>' +
@@ -6721,6 +6749,7 @@ JiTA.ui = {
         return '<div class="jita-side-subhead"><span id="jita-sd-title">Similar defects</span>' +
                '<input id="jita-sd-filter" type="text" placeholder="Filter…" autocomplete="off" title="Filter the whole database by this text (key / title / description) and show the best matches">' +
                '<span id="jita-sd-filterbtn" title="Filter results (status / recency)">' + JiTA.ui._funnelSvg + '</span>' +
+               '<span id="jita-sd-dupbtn" style="display:none" title="Show possible duplicate reports">' + JiTA.ui._dupSvg + '</span>' +
                '<span id="jita-sd-mode" title="Click to switch ranking mode (resets to automatic on reload)">Keyword</span></div>' +
                '<div id="jita-sd-status"></div>' +
                '<div id="jita-sd-loglink"></div>' +
@@ -7451,6 +7480,7 @@ JiTA.ui = {
     renderEbrDups: function (key, background) {
         var $box = $('#jita-sd-ebrdups');
         if (!$box.length) { return; }
+        if (!JiTA.ui._dupOn()) { $box.removeClass('has-hits').empty(); return; }   // gated behind the dup-reports toggle (off by default)
         if (!background) { $box.removeClass('has-hits').empty(); }
         JiTA.db.countEbr().then(function (n) {
             if (!n) { $box.removeClass('has-hits').empty(); return; }
@@ -7593,6 +7623,7 @@ JiTA.ui = {
         if (JiTA.ui.reporterMode) { return JiTA.ui.renderReporterReports(key); }
         JiTA.ui._ensurePanel();
         JiTA.ui._syncFilterBtn();   // reflect any active session filters on the funnel
+        JiTA.ui._syncDupBtn(true);  // dup-reports toggle is EBR-only -> show it here
         var terms = JiTA.ui._filterTerms();   // filter box: restrict the ranked corpus to these terms (whole DB)
         $('#jita-sd-title').text('Similar defects');   // reset title (the panel is shared with the EDR reports view)
         $('#jita-sd-exccluster').removeClass('has-hits').empty();   // defect-only section; clear it on the EBR view
@@ -7638,6 +7669,7 @@ JiTA.ui = {
     renderReports: function (key, background) {
         JiTA.ui._ensurePanel();
         JiTA.ui._syncFilterBtn();   // reflect any active session filters on the funnel
+        JiTA.ui._syncDupBtn(false);  // dup-reports toggle is EBR-only -> hide it on the defect view
         var terms = JiTA.ui._filterTerms();   // filter box: restrict the ranked corpus to these terms (whole DB)
         $('#jita-sd-title').text('Matching bug reports');
         $('#jita-sd-loglink').removeClass('has-hits').empty();   // EBR-only section; unused on a defect
@@ -7687,6 +7719,7 @@ JiTA.ui = {
         $('#jita-sd-exccluster').removeClass('has-hits').empty();     // defect-only section
         $('#jita-sd-loglink').removeClass('has-hits').empty();        // similar-defects-only section
         $('#jita-sd-ebrdups').removeClass('has-hits').empty();        // dup-reports section, not shown in this view
+        JiTA.ui._syncDupBtn(false);                                   // hide the EBR-only dup toggle in the reporter view
         $('#jita-sd-list').empty();
         JiTA.ui.setStatus('Finding this reporter’s other reports…');
         JiTA.ui._getReporterId(key).then(function (rid) {


### PR DESCRIPTION
A batch of the improvement-roadmap items you picked.

## 1. "Possible duplicate reports" on EBRs (the must-have)
Players file the same bug repeatedly, but the EBR panel only ranked DEFECTS. New **#jita-sd-ebrdups** section lists OTHER open bug reports that closely match this one, via the same engine the defect view uses (`rank.suggestEbrBest` over the EBR index), **excluding self**, filtered to `>= EBR_DUP_MIN_PCT` (40%) so unrelated reports don't show phantom dups, top `EBR_DUP_LIMIT` (5). Compact rows (key + score + summary) that open in a new tab and share the suggestions' hover preview; mirrors the loglink section (own CSS for both themes, snapshot-included, background/atomic-refill so it never flashes, cleared on the defect + reporter views).

## 2. Match Cython `.pyx` frames in log signatures
`\.py` -> `\.pyx?` in `_fingerprint` + worker `lgFp`. EVE is heavily Cython, so `.pyx` frames were silently dropped from every crash signature. Pure recall win for "Known defects in attached log".

## 3. Inline Sync/Retry in the panel's empty/error states
"No local data yet [Sync now]" / "Error: ... [Retry]" (new `setStatusAction`) instead of "go hunt the Tampermonkey menu".

## 4. Quieter flash-suppressor observer
`hideLogs` no longer runs a full-document `querySelectorAll` per comment keystroke - characterData-only mutations with no parse pending are skipped. Log detection unchanged (logs mount via childList).

`node --check` passes. Verified: self is excluded from its own dup list; result fields match what `renderReports` already renders.

## Test
- Open an EBR that's likely a dup of an existing report -> **Possible duplicate reports** appears with the matches; open a clearly-unique report -> section stays hidden (the 40% floor). Tell me if the floor feels too high/low - it's one constant to tune.
- `.pyx`-heavy log -> "Known defects in attached log" finds more matches.
- Fresh install -> inline **Sync now**; transient error -> **Retry**.
- Typing a comment: no per-keystroke overhead; log flash still suppressed.

Branched from `main` (3.6.3). **v3.7.0.**